### PR TITLE
Updating value formats for percent promoter measures (nps_user_monthly_score.view)

### DIFF
--- a/data_warehouse/data_warehouse_views/mattermost/nps_user_monthly_score.view.lkml
+++ b/data_warehouse/data_warehouse_views/mattermost/nps_user_monthly_score.view.lkml
@@ -195,21 +195,21 @@ view: nps_user_monthly_score {
   measure: pct_promoter_score {
     group_label: "Percents"
     type: number
-    value_format: "@{percent}"
+    value_format_name: percent_1
     sql: ${count_promoters}::float/${count_users}::float ;;
   }
 
   measure: pct_detractor_score {
     group_label: "Percents"
     type: number
-    value_format: "@{percent}"
+    value_format_name: percent_1
     sql: ${count_detractors}::float/${count_users}::float ;;
   }
 
   measure: pct_passive_score {
     group_label: "Percents"
     type: number
-    value_format: "@{percent}"
+    value_format_name: percent_1
     sql: ${count_passive}::float/${count_users}::float ;;
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This is a small change to the nps_user_monthly_score.view file to update the percent formatting of 3 measures.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

