### PR TITLE
Adding Salesforce Account table to filter out paid customers

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -2079,6 +2079,12 @@ explore: server_fact {
     relationship: one_to_many
   }
 
+  join: account {
+    view_label: "Salesforce Accounts"
+    sql_on: ${license_server_fact.account_sfid} = ${account.sfid};;
+    relationship: many_to_one
+  }
+
   join: lead {
     view_label: "Lead (Salesforce)"
     sql_on:  ${license_server_fact.license_email} = ${lead.email} ;;


### PR DESCRIPTION
Hi, 

Adding Salesforce Account table. 

Impact - 
1) Salesforce Account table contains information about paying customers. As per request, we need to filter out these customers from the dashboard.
2) Tested the changes locally on Snowflake, and the filter works as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

