### PR TITLE
Adding a derived table to filter Salesforce customers from Clearbit report

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -2079,12 +2079,6 @@ explore: server_fact {
     relationship: one_to_many
   }
 
-  join: account {
-    view_label: "Salesforce Accounts"
-    sql_on: ${license_server_fact.account_sfid} = ${account.sfid};;
-    relationship: many_to_one
-  }
-
   join: lead {
     view_label: "Lead (Salesforce)"
     sql_on:  ${license_server_fact.license_email} = ${lead.email} ;;
@@ -2136,6 +2130,15 @@ explore: server_fact {
       server_daily_details_ext.enable_jitsi_count, server_daily_details_ext.enable_mscalendar_count, server_daily_details_ext.enable_todo_count, server_daily_details_ext.enable_skype4business_count, server_daily_details_ext.enable_giphy_count,
       server_daily_details_ext.enable_digital_ocean_count, server_daily_details_ext.enable_incident_response_count, server_daily_details_ext.enable_memes_count, server_daily_details_ext.enable_matterpoll_count,
       server_daily_details_ext.enable_channel_recommender_count, server_daily_details_ext.enable_agenda_count, server_daily_details_ext.enable_msteamsmeeting_count, server_daily_details_ext.enable_icebreaker_count]
+  }
+
+}
+
+view: salesforce_customers {
+  derived_table: {
+    sql:select distinct customer_name
+              from blp.license_server_fact lsf
+              join orgm.ACCOUNT a on lsf.account_sfid = a.sfid where type in ('Customer','Customer (Attrited)');;
   }
 }
 


### PR DESCRIPTION
1) Removed Salesforce Customers table, as we are unable to use them as a filter. Created a view instead with a derived table, which we could use as a filter.
2) Yet to be tested after this PR would be merged.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

