### PR TITLE
Adding Salesforce Account to Focalboard Looker explore

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3852,7 +3852,6 @@ explore: focalboard_event_telemetry {
     fields: []
   }
 
-
   join: server_daily_details {
     view_label: "User Events Telemetry (Boards)"
     sql_on: ${focalboard_event_telemetry.user_id} = ${server_daily_details.server_id}
@@ -3866,6 +3865,13 @@ explore: focalboard_event_telemetry {
     sql_on: TRIM(${focalboard_event_telemetry.user_id}) = TRIM(${server_fact.server_id}) ;;
     relationship: many_to_one
     fields: [server_fact.installation_id, server_fact.first_server_version, server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.server_edition, server_fact.cloud_server, server_fact.max_registered_users]
+  }
+
+  join: account {
+    view_label: "Salesforce Account"
+    sql_on: ${license_server_fact.account_sfid} = ${account.sfid} ;;
+    relationship: many_to_one
+    fields: []
   }
 }
 


### PR DESCRIPTION
1) Impact: Adding Salesforce Account table to Focalboard explore. The request is to filter focalboard data in Customer 360 dashboard based on the account selected. By adding this join the Focalboard data would be filtered for the Salesforce Account selected.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

