### PR TITLE
Adding account name and SFID for dashboard filter to apply on tile

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3869,9 +3869,11 @@ explore: focalboard_event_telemetry {
 
   join: account {
     view_label: "Salesforce Account"
-    sql_on: ${license_server_fact.account_sfid} = ${account.sfid} ;;
+    sql_on: ${license_server_fact.account_sfid} = ${account.sfid}
+    AND ${license_server_fact.server_id} = ${server_daily_details.server_id}
+    AND ${focalboard_event_telemetry.user_id} = ${server_daily_details.server_id};;
     relationship: many_to_one
-    fields: []
+    fields: [account.name, account.sfid]
   }
 }
 


### PR DESCRIPTION
1) Impact: Adding account name and SFID to the explore, as we want the Customer 360 dashboard filter applies to the focalboard tile.



<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

