### PR TITLE
Adding Salesforce Account to Playbooks telemetry explore

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3042,6 +3042,7 @@ explore: incident_response_events {
   group_label: " Product: Playbooks"
   extends: [license_server_fact]
 
+
   join: server_daily_details {
     view_label: " User Events Telemetry (Playbooks)"
     sql_on: TRIM(${incident_response_events.user_id}) = TRIM(${server_daily_details.server_id}) AND ${incident_response_events.timestamp_date} = ${server_daily_details.logging_date} ;;
@@ -3068,6 +3069,14 @@ explore: incident_response_events {
     view_label: "License Details"
     sql_on: TRIM(${license_server_fact.server_id}) = TRIM(${incident_response_events.user_id}) AND ${incident_response_events.timestamp_date}::DATE BETWEEN ${license_server_fact.start_date}::date AND ${license_server_fact.license_retired_date}::date ;;
     relationship: many_to_one
+  }
+
+  join: account {
+    view_label: "Salesforce Account"
+    sql_on: ${license_server_fact.account_sfid} = ${account.sfid}
+    AND TRIM(${incident_response_events.user_id}) = TRIM(${license_server_fact.server_id}) ;;
+    relationship: many_to_one
+    fields: [account.name,account.sfid]
   }
 
   join: license_current {


### PR DESCRIPTION
1) Impact: Adding Salesforce Account and 2 fields name and SFID from account table, so the Customer 360 Filter can be applied on the playbooks tile.
2) Testing: Tested within Looker and works as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

