### PR TITLE
Fix the logic for new dimension cloud_server in performance_events

### DIFF
--- a/views/events/performance_events.view.lkml
+++ b/views/events/performance_events.view.lkml
@@ -16,7 +16,7 @@ view_label: " Performance Events"
     sql: CASE WHEN ${server_daily_details.installation_id} is not null THEN TRUE
             WHEN ${license_server_fact.cloud_customer} THEN TRUE
             WHEN ${server_fact.installation_id} is not null THEN TRUE
-            WHEN (${server_id} = '93mykbogbjfrbbdqphx3zhze5c' AND ${last_score_date}::date >= '2020-10-09'::date) THEN TRUE
+            WHEN (${user_id} = '93mykbogbjfrbbdqphx3zhze5c' AND ${timestamp_date}::date >= '2020-10-09'::date) THEN TRUE
             ELSE FALSE END ;;
   }
 


### PR DESCRIPTION
1) Impact: There is a new dimension called cloud_server created in performance events. The logic for the new dimension is looking at fields that do not exist in performance_events. This PR updates the code to point to the right fields in the view. 
2) Testing: The code for this view fails when we try to validate the LookML, I validated the LookML after this change and found no issues.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

