### PR TITLE
Adding new measure to server_fact & removing Account from server_fact

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -2085,12 +2085,6 @@ explore: server_fact {
     relationship: one_to_many
   }
 
-  join: account {
-    view_label: "Salesforce Accounts"
-    sql_on: ${license_server_fact.account_sfid} = ${account.sfid};;
-    relationship: many_to_one
-  }
-
   join: lead {
     view_label: "Lead (Salesforce)"
     sql_on:  ${license_server_fact.license_email} = ${lead.email} ;;

--- a/views/mattermost/server_fact.view.lkml
+++ b/views/mattermost/server_fact.view.lkml
@@ -1618,6 +1618,14 @@ view: server_fact {
     drill_fields: [drill_set1*]
   }
 
+  measure: retained_1day_user_sum {
+    label: "1-Day Retained Users"
+    description: "The sum of users that performed events within 24 & 48 hours of the instances first active timestamp across all servers in the current grouping."
+    type: number
+    sql: sum(${retention_1day_users}}) ;;
+    drill_fields: [drill_set1*]
+  }
+
   measure: server_version_list {
     label: "Server Versions"
     type: string


### PR DESCRIPTION
1) Impact: 
1. For a previous request to remove paid customers from Clearbit dashboard, I joined Salesforce Account to server_fact. This is no longer needed as we have taken a different approach (the Account is sometimes throwing errors of fields not found).
2. For the growth scorecard we created a new field retention_1day_users, this field needs to appear as a measure in the explore.

2) Testing: The changes will reflect once this PR is merged.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

