### PR TITLE
Adding Installation ID field to derived view retention_rate

### DIFF
--- a/derived_views/growth_scorecard/day1_retention_rate.view.lkml
+++ b/derived_views/growth_scorecard/day1_retention_rate.view.lkml
@@ -6,16 +6,16 @@ view: day1_retention_rate {
       , first_server_edition as "first_server_edition"
       , server_id as "server_id"
       , retention_1day_flag as "retention_1day_flag"
+      , installation_id as "installation_id"
       FROM (
       SELECT DISTINCT server_fact.server_id
       , (CASE WHEN COALESCE(server_fact.retention_1day_flag, false)  THEN 'Yes' ELSE 'No' END) AS retention_1day_flag
       ,server_fact.first_active_date::DATE AS first_active_date
       , CASE WHEN server_fact.first_server_edition = 'true' THEN 'E0' WHEN server_fact.first_server_edition = 'false' THEN 'TE' ELSE NULL END first_server_edition
+      , server_fact.installation_id
             FROM mattermost.server_fact AS server_fact
       LEFT JOIN mattermost.excludable_servers AS excludable_servers ON server_fact.server_id = excludable_servers.server_id
-      WHERE (NOT (CASE WHEN server_fact.installation_id IS NOT NULL THEN TRUE ELSE FALSE END )
-      OR (CASE WHEN server_fact.installation_id IS NOT NULL THEN TRUE ELSE FALSE END ) IS NULL)
-      AND (server_fact.first_active_date) >= (TO_TIMESTAMP('2020-02-02'))
+      WHERE (server_fact.first_active_date) >= (TO_TIMESTAMP('2020-02-02'))
       AND excludable_servers.reason IS NULL
       ) ORDER BY first_active_date
        ;;
@@ -27,6 +27,7 @@ view: day1_retention_rate {
   }
 
 # DIMENSIONS
+
   dimension: first_active_date {
     label: "First Active Date"
     type: date
@@ -51,6 +52,20 @@ view: day1_retention_rate {
     sql: ${TABLE}."retention_1day_flag" ;;
   }
 
+  dimension: installation_id {
+    label: "Installation ID"
+    description: "The unique ID provided to cloud servers."
+    type: string
+    sql: ${TABLE}."installation_id" ;;
+  }
+
+  dimension: cloud_server {
+    label: "Cloud Workspace"
+    description: "Indicates whether the server is using Mattermost's cloud product."
+    type: yesno
+    sql: CASE WHEN ${installation_id} IS NOT NULL THEN TRUE ELSE FALSE END ;;
+  }
+
   measure: instance_count {
     label: "Instance Count"
     group_label: " Instance Counts"
@@ -73,7 +88,7 @@ view: day1_retention_rate {
   }
 
   set: detail {
-    fields: [first_active_date, first_server_edition, server_id, retention_1day_flag, instance_count,
+    fields: [first_active_date, first_server_edition, server_id, retention_1day_flag, installation_id, cloud_server, instance_count,
       active_instances_day1, inactive_instances_day1]
   }
 }


### PR DESCRIPTION
1) Impact: Removed the cloud filter from the query and adding functionality to filter in the dashboard, for Cloud and Self Hosted.
2) Testing: Changes have been tested in Looker, using the test functionality and work as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

