### PR TITLE
Adding new fields for Cloud Sign-Up Funnel

### DIFF
--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -350,6 +350,44 @@ view: user_events_telemetry {
     hidden: no
   }
 
+  dimension: name {
+    label: "Name"
+    description: "The name of the event."
+    type: string
+    sql: ${TABLE}.name;;
+    hidden: no
+  }
+
+  dimension: sign_up_seqence {
+    label: "Chronological Sequence for Cloud Sign-up"
+    type: number
+    sql: CASE WHEN COALESCE(${type}, ${event}) like '%signup%' THEN 1
+      WHEN COALESCE(${type}, ${event}) like '%verify_email%' THEN 2
+      WHEN COALESCE(${type}, ${event}) like '%enter_valid_code%' THEN 3
+      WHEN COALESCE(${type}, ${event}) like '%create_workspace%' and ${name} like '%pageview_company_name%' THEN 4
+      WHEN COALESCE(${type}, ${event}) like 'workspace_name_valid' THEN 5
+      WHEN COALESCE(${type}, ${event}) like '%workspace_provisioning_started%' THEN 6
+      WHEN COALESCE(${type}, ${event}) like '%workspace_provisioning_ended%' THEN 7
+      ELSE NULL
+      end;;
+    hidden: no
+  }
+
+  dimension: sign_up_events_sequence {
+    label: "Event Sequence for Cloud Sign-up"
+    type: string
+    sql: CASE WHEN COALESCE(${type}, ${event}) like '%signup%' THEN 'Sign-Up Page'
+      WHEN COALESCE(${type}, ${event}) like '%verify_email%' THEN 'Verify Email'
+      WHEN COALESCE(${type}, ${event}) like '%enter_valid_code%' THEN 'Enter Valid Code'
+      WHEN COALESCE(${type}, ${event}) like '%create_workspace%' and ${name} like '%company_name%' THEN 'Enter Company Name'
+      WHEN COALESCE(${type}, ${event}) like '%workspace_name_valid%' THEN 'Workspace Name Valid'
+      WHEN COALESCE(${type}, ${event}) like '%workspace_provisioning_started%' THEN 'Workspace Creation Started'
+      WHEN COALESCE(${type}, ${event}) like '%workspace_provisioning_ended%' THEN 'Workspace Created'
+      ELSE NULL
+      end;;
+    hidden: no
+  }
+
   dimension: context_traits_server {
     group_label: "Context Attributes"
     description: ""


### PR DESCRIPTION
Impact: The current table cloud on-boarding flows describes the flow for sign-ups. The table is outdated and there were many more new type of events created. These new fields eliminate the join into cloud onboarding flows which is no longer updated and creates the flow within the table itself. These changes are closer to recent and upcoming changes to events and Growth team, also fully customizable.
Testing: Changes have been tested locally and the tile has been added to the Growth Scoreboard.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

