### PR TITLE
Adding new view for New User Retention Rate

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3958,3 +3958,38 @@ explore: performance_events {
     fields: []
   }
   }
+
+explore: user_retention {
+  label: " User Retention"
+  group_label: " Product: Messaging"
+  hidden: no
+
+  join: server_fact {
+    view_label: " Server Fact"
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${user_retention.server_id} = ${server_fact.server_id} ;;
+  }
+
+  join: license_server_fact {
+    view_label: " License Server Fact"
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${user_retention.server_id} = ${license_server_fact.server_id} ;;
+  }
+
+  join: trial_requests {
+    view_label: " Trial Requests"
+    sql_on: ${trial_requests.license_id} = ${license_server_fact.license_id} ;;
+    relationship: many_to_one
+    type: left_outer
+    fields: []
+  }
+
+  join: excludable_servers {
+    view_label: " Excludable Servers"
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${user_retention.server_id} = ${excludable_servers.server_id} ;;
+  }
+}

--- a/views/mattermost/user_retention.view.lkml
+++ b/views/mattermost/user_retention.view.lkml
@@ -1,0 +1,132 @@
+view: user_retention {
+
+  sql_table_name: "MATTERMOST"."USER_RETENTION";;
+  drill_fields: [id]
+
+
+  dimension: id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}."ID" ;;
+  }
+
+  dimension_group: first_active_timestamp {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}."FIRST_ACTIVE_TIMESTAMP" ;;
+  }
+
+  dimension: first_server_edition {
+    type: string
+    sql: ${TABLE}."FIRST_SERVER_EDITION" ;;
+  }
+
+  dimension: installation_id {
+    label: "Installation ID"
+    description: "The Installation ID of the user."
+    type: string
+    sql: ${TABLE}."INSTALLATION_ID" ;;
+  }
+
+  dimension: retention_14_day_flag {
+    type: yesno
+    sql: ${TABLE}."RETENTION_14DAY_FLAG" ;;
+  }
+
+  dimension: retention_1_day_flag {
+    type: yesno
+    sql: ${TABLE}."RETENTION_1DAY_FLAG" ;;
+  }
+
+  dimension: retention_28_day_flag {
+    type: yesno
+    sql: ${TABLE}."RETENTION_28DAY_FLAG" ;;
+  }
+
+  dimension: retention_7_day_flag {
+    type: yesno
+    sql: ${TABLE}."RETENTION_7DAY_FLAG" ;;
+  }
+
+  dimension: server_id {
+    label: "Instance Id"
+    description: "The Instance Id of the user."
+    type: string
+    sql: ${TABLE}."SERVER_ID" ;;
+  }
+
+  dimension: user_id {
+    label: "User ID"
+    description: "The User Id of the user."
+    type: string
+    sql: ${TABLE}."USER_ID" ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [id]
+  }
+
+  measure: server_count {
+    group_label: "Instance Counts"
+    label: "Total Instances"
+    description: "The distinct count of Instances."
+    type: count_distinct
+    sql:  ${server_id} ;;
+    drill_fields: [id]
+  }
+
+  measure: user_count {
+    group_label: "User Counts"
+    label: "Total Users"
+    description: "The distinct count of Users."
+    type: count_distinct
+    sql:  ${user_id} ;;
+    drill_fields: [id]
+  }
+
+  measure: retention_1_day_users {
+    group_label: "User Counts"
+    label: "Retained Day 1 Users"
+    description: "The distinct count of servers/workspaces with Retained Day 1 Users marked true."
+    type: count_distinct
+    sql: CASE WHEN ${retention_1_day_flag} THEN ${user_id} ELSE NULL END;;
+    drill_fields: [id]
+  }
+
+  measure: retention_7_day_users {
+    group_label: "User Counts"
+    label: "Retained Day 7 Users"
+    description: "The distinct count of servers/workspaces with Retained Day 7 Users marked true."
+    type: count_distinct
+    sql: CASE WHEN ${retention_7_day_flag} THEN ${user_id} ELSE NULL END;;
+    drill_fields: [id]
+  }
+
+  measure: retention_14_day_users {
+    group_label: "User Counts"
+    label: "Retained Day 14 Users"
+    description: "The distinct count of servers/workspaces with Retained Day 14 Users marked true."
+    type: count_distinct
+    sql: CASE WHEN ${retention_14_day_flag} THEN ${user_id} ELSE NULL END;;
+    drill_fields: [id]
+  }
+
+  measure: retention_28_day_users {
+    group_label: "User Counts"
+    label: "Retained 28 Day Users"
+    description: "The distinct count of servers/workspaces with Retained Day 28 Users marked true."
+    type: count_distinct
+    sql: CASE WHEN ${retention_28_day_flag} THEN ${user_id} ELSE NULL END;;
+    drill_fields: [id]
+  }
+
+}


### PR DESCRIPTION
Impact: Existing User 28 Retention table only calculates Retention for Day 28 metrics. This is a new view which will serve the needs for all types of User Retention Rates. Currently this view has Day 1, 7, 14 and 28 Retention Rate calculations.
Testing: The dashboard was built using new Looker explore feature and works as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

