### PR TITLE
Creating a new view and adding the view to explore for Focalboard Analytics dashboard

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3993,3 +3993,9 @@ explore: user_retention {
     sql_on: ${user_retention.server_id} = ${excludable_servers.server_id} ;;
   }
 }
+
+explore: focalboard_user_retention {
+  label: " Focalboard User Retention"
+  group_label: " Product: Boards"
+  hidden: no
+}

--- a/views/focalboard_user_retention.view.lkml
+++ b/views/focalboard_user_retention.view.lkml
@@ -1,0 +1,101 @@
+view: focalboard_user_retention {
+
+  sql_table_name: "MATTERMOST"."FOCALBOARD_USER_RETENTION"
+    ;;
+  drill_fields: [id]
+
+
+  dimension: id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}."ID" ;;
+  }
+
+  dimension: age {
+    type: string
+    sql: ${TABLE}."AGE" ;;
+  }
+
+  dimension: sorting_order {
+    case: {
+      when: {
+        sql: ${age} = 'AGE 0' ;;
+        label: "AGE 0"
+      }
+      when: {
+        sql: ${age} = 'AGE 1 - 6' ;;
+        label: "AGE 1 - 6"
+      }
+      when: {
+        sql: ${age} = 'AGE 7 - 27' ;;
+        label: "AGE 7 - 27"
+      }
+      when: {
+        sql: ${age} = 'AGE 28' ;;
+        label: "AGE 28"
+      }
+    }
+  }
+
+  dimension_group: first_active_timestamp {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}."FIRST_ACTIVE_TIMESTAMP" ;;
+  }
+
+  dimension: first_server_edition {
+    type: string
+    sql: ${TABLE}."FIRST_SERVER_EDITION" ;;
+  }
+
+  dimension: installation_id {
+    type: string
+    sql: ${TABLE}."INSTALLATION_ID" ;;
+  }
+
+  dimension_group: max_active_timestamp {
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    sql: ${TABLE}."MAX_ACTIVE_TIMESTAMP" ;;
+  }
+
+  dimension: server_id {
+    label: " Instance ID"
+    type: string
+    sql: ${TABLE}."SERVER_ID" ;;
+  }
+
+  dimension: user_id {
+    label: " User ID"
+    type: string
+    sql: ${TABLE}."USER_ID" ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [id]
+  }
+
+  measure: user_count {
+    label: " User Count"
+    type: count_distinct
+    sql:  ${user_id} ;;
+    drill_fields: [id]
+  }
+}

--- a/views/mattermost/focalboard_user_retention.view.lkml
+++ b/views/mattermost/focalboard_user_retention.view.lkml
@@ -31,8 +31,8 @@ view: focalboard_user_retention {
         label: "AGE 7 - 27"
       }
       when: {
-        sql: ${age} = 'AGE 28' ;;
-        label: "AGE 28"
+        sql: ${age} = 'AGE 28+' ;;
+        label: "AGE 28+"
       }
     }
   }


### PR DESCRIPTION
Impact: Currently the focalboard team has a few dashboards they run on a google doc. This view and addition to the explore eliminates the use of the google spreadsheet, and adds the same plot to the Focalboard Analytics dashboard.
Testing: Changes have been tested and the dashboard has been created and added to Focalboard Analytics dashboard using Looker explore feature.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

