### PR TITLE
Adding new dimension to Trial Requests and joining LSF to Calls

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -396,6 +396,12 @@ explore: calls_events {
     sql_on: ${calls_events.timestamp_date} = ${dates.date_date} ;;
     relationship: many_to_one
   }
+
+  join: license_server_fact {
+    sql_on: ${calls_events.user_id} = ${license_server_fact.server_id} ;;
+    relationship: many_to_one
+    fields: []
+  }
 }
 
 explore: opportunity_snapshot {
@@ -3012,11 +3018,11 @@ explore: license_server_fact {
   }
 
   join: trial_requests {
+    view_label: " Trial Requests"
     sql_on: ${trial_requests.license_id} = ${license_server_fact.license_id} ;;
     relationship: many_to_one
     type: left_outer
-    fields: []
-
+    fields: [trial_requests.server_id, trial_requests.count, trial_requests.license_id, trial_requests.product_type]
   }
 
   join: person {

--- a/views/blapi/trial_requests.view.lkml
+++ b/views/blapi/trial_requests.view.lkml
@@ -1,6 +1,5 @@
 view: trial_requests {
-  sql_table_name: "BLAPI"."TRIAL_REQUESTS"
-    ;;
+  sql_table_name: "BLAPI"."TRIAL_REQUESTS";;
 
   dimension: sfid {
     hidden: yes
@@ -92,6 +91,12 @@ view: trial_requests {
     sql: ${TABLE}."SITE_URL" ;;
   }
 
+  dimension: product_type {
+    label: "Product Type"
+    type: string
+    sql: CASE WHEN ${site_url} LIKE '%mattermost.com%' THEN 'Website' ELSE 'Self-Hosted' END ;;
+  }
+
   dimension_group: start {
     type: time
     timeframes: [
@@ -122,4 +127,6 @@ view: trial_requests {
     type: count_distinct
     sql: ${license_id} ;;
   }
+
+
 }


### PR DESCRIPTION
Impact: Adding new dimension product_type to Trial Requests to distinguish between In-Product and Website for Self Hosted Instances. Also joining license_server_fact to Calls, for additions to Calls dashboard.

Testing: Changes have been tested using Looker explore feature, once this PR is merged, the new visualization will show up on the Growth Dashboard.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

