### PR TITLE
Importing new view for Performance events analysis

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3913,7 +3913,7 @@ explore: performance_events_duration {
   hidden: no
 
   join: server_daily_details {
-    view_label: " Performance Events  (Middle 90% Duration)"
+    view_label: " Server Daily Details"
     sql_on: ${performance_events_duration.user_id} = ${server_daily_details.server_id} AND ${performance_events_duration.timestamp_date} = ${server_daily_details.logging_date} ;;
     relationship: many_to_one
     type: left_outer
@@ -3935,28 +3935,28 @@ explore: performance_events_duration {
   }
 
   join: excludable_servers {
-    view_label: " Performance Events  (Middle 90% Duration)"
+    view_label: " Excludable Servers"
     sql_on: ${performance_events_duration.user_id} = ${excludable_servers.server_id} ;;
     relationship: many_to_one
     fields: [excludable_servers.reason]
   }
 
   join: user_agent_registry {
-    view_label: " Performance Events  (Middle 90% Duration)"
+    view_label: " User Agent Registry"
     relationship: many_to_one
     sql_on: ${performance_events_duration.context_useragent} = ${user_agent_registry.context_useragent} ;;
     fields: [user_agent_registry.browser_version_major, user_agent_registry.bot, user_agent_registry.browser, user_agent_registry.browser_version, user_agent_registry.browser_w_version_major, user_agent_registry.browser_w_version, user_agent_registry.os_w_version, user_agent_registry.os_w_version_major]
   }
 
   join: subscriptions {
-    view_label: "Stripe"
+    view_label: " Subscriptions"
     relationship: one_to_one
     sql_on: ${subscriptions.cws_installation} = ${server_fact.installation_id} ;;
     fields: []
   }
 
   join: customers {
-    view_label: "Stripe"
+    view_label: " Stripe"
     relationship: one_to_one
     sql_on: ${subscriptions.customer} = ${customers.id} ;;
     fields: []

--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3907,6 +3907,76 @@ explore: focalboard_event_telemetry {
   }
 }
 
+explore: performance_events_duration {
+  label: " Performance Events (Middle 90% Duration)"
+  group_label: " Product: Messaging"
+  hidden: no
+
+  join: server_daily_details {
+    view_label: " Performance Events  (Middle 90% Duration)"
+    sql_on: ${performance_events_duration.user_id} = ${server_daily_details.server_id} AND ${performance_events_duration.timestamp_date} = ${server_daily_details.logging_date} ;;
+    relationship: many_to_one
+    type: left_outer
+    fields: [server_daily_details.database_version, server_daily_details.database_version_major, server_daily_details.database_version_major_release, server_daily_details.server_version_major, server_daily_details.version, server_daily_details.edition]
+  }
+
+  join: version_release_dates {
+    view_label: "Version Release Dates"
+    sql_on: ${server_fact.server_version_major} = split_part(${version_release_dates.version}, '.', 1) || '.' || split_part(${version_release_dates.version}, '.', 2) ;;
+    relationship: many_to_one
+    fields: [version_release_dates.release_date, version_release_dates.supported]
+  }
+
+  join: server_fact {
+    view_label: "Server Fact"
+    sql_on: ${performance_events_duration.user_id} = ${server_fact.server_id} ;;
+    relationship: many_to_one
+    fields: [server_fact.installation_id, server_fact.first_server_version, server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.cloud_server, server_fact.registered_users_max, server_fact.max_registered_deactivated_users]
+  }
+
+  join: excludable_servers {
+    view_label: " Performance Events  (Middle 90% Duration)"
+    sql_on: ${performance_events_duration.user_id} = ${excludable_servers.server_id} ;;
+    relationship: many_to_one
+    fields: [excludable_servers.reason]
+  }
+
+  join: user_agent_registry {
+    view_label: " Performance Events  (Middle 90% Duration)"
+    relationship: many_to_one
+    sql_on: ${performance_events_duration.context_useragent} = ${user_agent_registry.context_useragent} ;;
+    fields: [user_agent_registry.browser_version_major, user_agent_registry.bot, user_agent_registry.browser, user_agent_registry.browser_version, user_agent_registry.browser_w_version_major, user_agent_registry.browser_w_version, user_agent_registry.os_w_version, user_agent_registry.os_w_version_major]
+  }
+
+  join: subscriptions {
+    view_label: "Stripe"
+    relationship: one_to_one
+    sql_on: ${subscriptions.cws_installation} = ${server_fact.installation_id} ;;
+    fields: []
+  }
+
+  join: customers {
+    view_label: "Stripe"
+    relationship: one_to_one
+    sql_on: ${subscriptions.customer} = ${customers.id} ;;
+    fields: []
+  }
+
+  join: license_server_fact {
+    relationship: many_to_one
+    sql_on:
+          ${performance_events_duration.user_id} = ${license_server_fact.server_id}
+          and ${performance_events_duration.timestamp_date} between ${license_server_fact.start_date} AND ${license_server_fact.license_retired_date} ;;
+  }
+
+  join: trial_requests {
+    sql_on: ${trial_requests.license_id} = ${license_server_fact.license_id} ;;
+    relationship: many_to_one
+    type: left_outer
+    fields: []
+  }
+}
+
 
 explore: performance_events {
   label: " Performance Events"

--- a/views/events/performance_events_duration.view.lkml
+++ b/views/events/performance_events_duration.view.lkml
@@ -1,0 +1,715 @@
+# This is the view file for the analytics.events.performance_events table.
+  view: performance_events_duration {
+    sql_table_name: events.performance_events_duration ;;
+    view_label: " Performance Events (Middle 90% Duration)"
+
+
+
+### SETS
+
+### FILTERS
+
+    dimension: cloud_server {
+      type: yesno
+      description: "Boolean indicating the event was from a Mattermost Cloud workspace (vs. a server using Mattermost's on-prem offering)."
+      sql: CASE WHEN ${server_daily_details.installation_id} is not null THEN TRUE
+            WHEN ${license_server_fact.cloud_customer} THEN TRUE
+            WHEN ${server_fact.installation_id} is not null THEN TRUE
+            WHEN (${user_id} = '93mykbogbjfrbbdqphx3zhze5c' AND ${timestamp_date}::date >= '2020-10-09'::date) THEN TRUE
+            ELSE FALSE END ;;
+    }
+
+
+### DIMENSIONS
+
+
+
+    dimension: _dbt_source_relation {
+      label: " Dbt Source Relation"
+      description: "The  Dbt Source Relation of the user performing the event."
+      type: string
+      sql: ${TABLE}._dbt_source_relation ;;
+      hidden: yes
+    }
+
+
+    dimension: context_page_referrer {
+      label: "Context Page Referrer"
+      group_label: "Context/User Agent Details"
+      description: "The Context Page Referrer of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_page_referrer ;;
+    }
+
+
+    dimension: channel {
+      label: "Channel"
+      description: "The Channel of the user performing the event."
+      type: string
+      sql: ${TABLE}.channel ;;
+      hidden: yes
+    }
+
+
+    dimension: context_app_namespace {
+      label: "Context App Namespace"
+      group_label: "Context/User Agent Details"
+      description: "The Context App Namespace of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_app_namespace ;;
+    }
+
+
+    dimension: id {
+      label: "Id"
+      description: "The Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.id ;;
+      hidden: yes
+    }
+
+
+    dimension: user_actual_id {
+      label: " User Id"
+      description: "The User Id associated with the user that performed the event."
+      type: string
+      sql: ${TABLE}.user_actual_id ;;
+    }
+
+    dimension: context_library_name {
+      label: "Context Library Name"
+      group_label: "Context/User Agent Details"
+      description: "The Context Library Name of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_library_name ;;
+    }
+
+
+    dimension: type {
+      label: " Event Name (Type)"
+      description: "The name of the event performed."
+      type: string
+      sql: ${TABLE}.type ;;
+    }
+
+
+    dimension: context_app_version {
+      label: "Context App Version"
+      group_label: "Context/User Agent Details"
+      description: "The Context App Version of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_app_version ;;
+    }
+
+
+    dimension: user_actual_role {
+      label: " User Actual Role"
+      description: "The User Actual Role of the user performing the event."
+      type: string
+      sql: ${TABLE}.user_actual_role ;;
+    }
+
+
+    dimension: context_page_url {
+      label: "Context Page Url"
+      group_label: "Context/User Agent Details"
+      description: "The Context Page Url of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_page_url ;;
+    }
+
+
+    dimension: context_os_name {
+      label: "Context Os Name"
+      group_label: "Context/User Agent Details"
+      description: "The Context Os Name of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_os_name ;;
+    }
+
+
+    dimension: context_page_title {
+      label: "Context Page Title"
+      group_label: "Context/User Agent Details"
+      description: "The Context Page Title of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_page_title ;;
+    }
+
+
+    dimension: anonymous_id {
+      label: "Anonymous Id"
+      description: "The Anonymous Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.anonymous_id ;;
+      hidden: yes
+    }
+
+
+    dimension: context_app_build {
+      label: "Context App Build"
+      group_label: "Context/User Agent Details"
+      description: "The Context App Build of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_app_build ;;
+    }
+
+
+    dimension: context_page_search {
+      label: "Context Page Search"
+      group_label: "Context/User Agent Details"
+      description: "The Context Page Search of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_page_search ;;
+    }
+
+
+    dimension: context_library_version {
+      label: "Context Library Version"
+      group_label: "Context/User Agent Details"
+      description: "The Context Library Version of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_library_version ;;
+    }
+
+
+    dimension: context_ip {
+      label: "Context Ip"
+      group_label: "Context/User Agent Details"
+      description: "The Context Ip of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_ip ;;
+    }
+
+
+    dimension: context_useragent {
+      label: "Context Useragent"
+      group_label: "Context/User Agent Details"
+      description: "The Context Useragent of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_useragent ;;
+    }
+
+
+    dimension: context_app_name {
+      label: "Context App Name"
+      group_label: "Context/User Agent Details"
+      description: "The Context App Name of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_app_name ;;
+    }
+
+
+    dimension: context_locale {
+      label: "Context Locale"
+      group_label: "Context/User Agent Details"
+      description: "The Context Locale of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_locale ;;
+    }
+
+
+    dimension: context_screen_density {
+      label: "Context Screen Density"
+      group_label: "Context/User Agent Details"
+      description: "The Context Screen Density of the instance."
+      type: string
+      sql: ${TABLE}.context_screen_density ;;
+    }
+
+
+
+    dimension: context_page_path {
+      label: "Context Page Path"
+      group_label: "Context/User Agent Details"
+      description: "The Context Page Path of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_page_path ;;
+    }
+
+
+    dimension: context_os_version {
+      label: "Context Os Version"
+      group_label: "Context/User Agent Details"
+      description: "The Context Os Version of the user performing the event."
+      type: string
+      sql: ${TABLE}.context_os_version ;;
+    }
+
+
+    dimension: category {
+      label: " Event Category"
+      description: "The category of the event performed."
+      type: string
+      sql: ${TABLE}.category ;;
+    }
+
+
+    dimension: duration {
+      label: "Duration"
+      description: "The Duration of the time taken for the performance event to load in milliseconds."
+      type: number
+      sql: ${TABLE}.duration ;;
+    }
+
+
+
+    dimension: user_id {
+      label: " Instance Id"
+      description: "The User Id (Instance ID) of the user performing the event."
+      type: string
+      sql: COALESCE(${TABLE}.user_id, ${TABLE}.userid) ;;
+    }
+
+
+    dimension: root_id {
+      label: "Root Id"
+      description: "The Root Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.root_id ;;
+    }
+
+
+    dimension: post_id {
+      label: "Post Id"
+      description: "The Post Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.post_id ;;
+    }
+
+
+    dimension: sort {
+      label: "Sort"
+      description: "The Sort of the user performing the event."
+      type: string
+      sql: ${TABLE}.sort ;;
+    }
+
+
+    dimension: team_id {
+      label: "Team Id"
+      description: "The Team Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.team_id ;;
+    }
+
+    dimension: version {
+      label: "Version"
+      description: "The Version of the user performing the event."
+      type: string
+      sql: ${TABLE}.version ;;
+    }
+
+
+    dimension: keyword {
+      label: "Keyword"
+      description: "The Keyword of the user performing the event."
+      type: string
+      sql: ${TABLE}.keyword ;;
+    }
+
+
+    dimension: count {
+      label: "Count"
+      description: "The Count of the instance."
+      type: string
+      sql: ${TABLE}.count ;;
+    }
+
+
+
+    dimension: gfyid {
+      label: "Gfyid"
+      description: "The Gfyid of the user performing the event."
+      type: string
+      sql: ${TABLE}.gfyid ;;
+    }
+
+
+    dimension: field {
+      label: "Field"
+      description: "The Field of the user performing the event."
+      type: string
+      sql: ${TABLE}.field ;;
+    }
+
+
+    dimension: plugin_id {
+      label: "Plugin Id"
+      description: "The Plugin Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.plugin_id ;;
+    }
+
+
+    dimension: installed_version {
+      label: "Installed Version"
+      description: "The Installed Version of the user performing the event."
+      type: string
+      sql: ${TABLE}.installed_version ;;
+    }
+
+
+    dimension: group_constrained {
+      label: "Group Constrained"
+      description: "Indicates Group Constrained is marked true/enabled."
+      type: yesno
+      sql: ${TABLE}.group_constrained ;;
+    }
+
+
+    dimension: value {
+      label: "Value"
+      description: "The Value of the user performing the event."
+      type: string
+      sql: ${TABLE}.value ;;
+    }
+
+
+    dimension: include_deleted {
+      label: "Include Deleted"
+      description: "Indicates Include Deleted is marked true/enabled."
+      type: yesno
+      sql: ${TABLE}.include_deleted ;;
+    }
+
+
+
+    dimension: role {
+      label: "Role"
+      description: "The Role of the user performing the event."
+      type: string
+      sql: ${TABLE}.role ;;
+    }
+
+
+    dimension: privacy {
+      label: "Privacy"
+      description: "The Privacy of the user performing the event."
+      type: string
+      sql: ${TABLE}.privacy ;;
+    }
+
+
+    dimension: scheme_id {
+      label: "Scheme Id"
+      description: "The Scheme Id of the user performing the event."
+      type: string
+      sql: ${TABLE}.scheme_id ;;
+    }
+
+
+    dimension: warnmetricid {
+      label: "Warnmetricid"
+      description: "The Warnmetricid attribute of the triggered event."
+      type: string
+      sql: ${TABLE}.warnmetricid ;;
+    }
+
+
+    dimension: metric {
+      label: "Metric"
+      description: "The Metric attribute of the triggered event."
+      type: string
+      sql: ${TABLE}.metric ;;
+    }
+
+
+    dimension: error {
+      label: "Error"
+      description: "The Error attribute of the triggered event."
+      type: string
+      sql: ${TABLE}.error ;;
+    }
+
+
+    dimension: num_invitations_sent {
+      label: "Num Invitations Sent"
+      description: "The Num Invitations Sent attribute of the invite members event."
+      type: string
+      sql: ${TABLE}.num_invitations_sent ;;
+    }
+
+
+    dimension: num_invitations {
+      label: "Num Invitations"
+      description: "The Num Invitations attribute of the invite members event."
+      sql: ${TABLE}.num_invitations ;;
+    }
+
+
+
+    dimension: channel_sidebar {
+      label: "Channel Sidebar"
+      description: "Indicates Channel Sidebar is marked true/enabled."
+      type: yesno
+      sql: ${TABLE}.channel_sidebar ;;
+    }
+
+
+
+    dimension: app {
+      label: "App"
+      description: "The App associated with the triggered event."
+      type: string
+      sql: ${TABLE}.app ;;
+    }
+
+
+    dimension: method {
+      label: "Method"
+      description: "The Method associated with the triggered event."
+      type: string
+      sql: ${TABLE}.method ;;
+    }
+
+
+    dimension: remaining {
+      label: "Remaining"
+      description: "The Remaining attribute associated with the triggered event."
+      type: string
+      sql: ${TABLE}.remaining ;;
+    }
+
+
+
+    dimension: screen {
+      label: "Screen"
+      description: "The Screen attribute associated with the triggered event."
+      type: string
+      sql: ${TABLE}.screen ;;
+    }
+
+
+    dimension: filter {
+      label: "Filter"
+      description: "The Filter attribute associated with the triggered event."
+      type: string
+      sql: ${TABLE}.filter ;;
+    }
+
+    dimension: server_version {
+      description: "The Mattermost server version associated with the user's server at the point in time that they submitted the performance event."
+      type: string
+      sql: CASE WHEN ${cloud_server} THEN 'Cloud' ELSE ${TABLE}.version END ;;
+      hidden: no
+      order_by_field: server_version_major_sort
+    }
+
+    dimension: server_version_major {
+      description: "The Mattermost server version (major) associated with the user's server at the point in time that they submitted the performance event."
+      type: string
+      sql: CASE WHEN ${cloud_server} THEN 'Cloud'
+          ELSE SPLIT_PART(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 1) ||
+          '.' || split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 2) END ;;
+      hidden: no
+      order_by_field: server_version_major_sort
+    }
+
+    dimension: server_version_major_sort {
+      group_label: " Server Versions"
+      label: "  Server Version: Major (Current)"
+      description: "Sorting of major server version."
+      type: number
+      sql: CASE WHEN ${cloud_server} THEN '1000000'::int
+          ELSE (split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 1) ||
+          CASE WHEN split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 2)::int < 10 THEN
+              ('0' || split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 2))
+            WHEN split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 2) = '10' THEN '99'
+            ELSE split_part(regexp_substr(${TABLE}.version,'^[0-9]{0,}[.]{1}[0-9[{0,}[.]{1}[0-9]{0,}[.]{1}[0-9]{0,}'), '.', 2) || '0' END)::int
+            END;;
+      hidden: yes
+    }
+
+
+### DATES & TIMESTAMPS
+
+
+
+    dimension_group: original_timestamp {
+      label: "Original Timestamp"
+      type: time
+      timeframes: [time, hour_of_day, hour6, date, week, month, year, fiscal_quarter, fiscal_year, day_of_week, fiscal_month_num,
+        week_of_year, day_of_year, day_of_week_index, month_name, day_of_month, fiscal_quarter_of_year]
+      sql: ${TABLE}.original_timestamp::date ;;
+
+      hidden: yes
+    }
+
+
+
+    dimension_group: sent_at {
+      label: "Sent At"
+      type: time
+      timeframes: [time, hour_of_day, hour6, date, week, month, year, fiscal_quarter, fiscal_year, day_of_week, fiscal_month_num,
+        week_of_year, day_of_year, day_of_week_index, month_name, day_of_month, fiscal_quarter_of_year]
+      sql: ${TABLE}.sent_at::date ;;
+
+      hidden: yes
+    }
+
+
+
+    dimension_group: uuid_ts {
+      label: "Uuid Ts"
+      type: time
+      timeframes: [time, hour_of_day, hour6, date, week, month, year, fiscal_quarter, fiscal_year, day_of_week, fiscal_month_num,
+        week_of_year, day_of_year, day_of_week_index, month_name, day_of_month, fiscal_quarter_of_year]
+      sql: ${TABLE}.uuid_ts::date ;;
+
+      hidden: yes
+    }
+
+    dimension_group: timestamp {
+      label: " Logging"
+      type: time
+      timeframes: [time, hour_of_day, hour6, date, week, month, year, fiscal_quarter, fiscal_year, day_of_week, fiscal_month_num,
+        week_of_year, day_of_year, day_of_week_index, month_name, day_of_month, fiscal_quarter_of_year]
+      sql: ${TABLE}.received_at ;;
+    }
+
+
+
+### MEASURES
+
+
+
+    measure: user_actual_id_count {
+      label: " User Count"
+      description: "The distinct count of User Actual Id's within the grouping."
+      type: count_distinct
+      sql: ${user_actual_id} ;;
+    }
+
+    measure: context_screen_density_sum {
+      group_label: "Screen Density Measures"
+      label: "Screen Density (Sum)"
+      description: "The sum of Context Screen Density across all instances within the grouping."
+      type: sum
+      sql: ${context_screen_density} ;;
+    }
+
+    measure: context_screen_density_avg {
+      group_label: "Screen Density Measures"
+      label: "Screen Density (Avg)"
+      description: "The average Context Screen Density across all instances within the grouping."
+      type: average
+      sql: ${context_screen_density} ;;
+    }
+
+    measure: context_screen_density_median {
+      group_label: "Screen Density Measures"
+      label: "Screen Density (Med)"
+      description: "The median Context Screen Density across all instances within the grouping."
+      type: median
+      sql: ${context_screen_density} ;;
+    }
+
+
+    measure: duration_sum {
+      group_label: "Duration Measures"
+      label: "Duration (Sum)"
+      description: "The sum of Duration across all instances within the grouping."
+      type: sum
+      value_format_name: decimal_0
+      sql: ${duration} ;;
+    }
+
+    measure: duration_avg {
+      group_label: "Duration Measures"
+      label: "Duration (Avg)"
+      description: "The average Duration across all instances within the grouping."
+      type: average
+      sql: ${duration} ;;
+      value_format_name: decimal_2
+    }
+
+    measure: duration_median {
+      group_label: "Duration Measures"
+      label: "Duration (Med)"
+      description: "The median Duration across all instances within the grouping."
+      type: median
+      sql: ${duration} ;;
+      value_format_name: decimal_1
+    }
+
+    measure: duration_p99 {
+      group_label: "Duration Measures"
+      label: "Duration (p99)"
+      description: "The 99th percentile Duration across all instances within the grouping."
+      type: percentile
+      percentile: 99
+      sql: ${duration} ;;
+      value_format_name: decimal_2
+    }
+
+
+    measure: user_id_count {
+      label: " Instance Count"
+      description: "The distinct count of User Id's (Instance ID's) within the grouping."
+      type: count_distinct
+      sql: ${user_id} ;;
+    }
+
+
+    measure: plugin_id_count {
+      group_label: "Plugin Counts"
+      label: "Plugin Id Count"
+      description: "The distinct count of Plugin Id's within the grouping."
+      type: count_distinct
+      sql: ${plugin_id} ;;
+    }
+
+
+    measure: num_invitations_sum {
+      group_label: "Num Invitations Measures"
+      label: "Num Invitations (Sum)"
+      description: "The sum of Num Invitations across all instances within the grouping."
+      type: sum
+      sql: ${num_invitations} ;;
+    }
+
+    measure: num_invitations_avg {
+      group_label: "Num Invitations Measures"
+      label: "Num Invitations (Avg)"
+      description: "The average Num Invitations across all instances within the grouping."
+      type: average
+      sql: ${num_invitations} ;;
+    }
+
+    measure: num_invitations_median {
+      group_label: "Num Invitations Measures"
+      label: "Num Invitations (Med)"
+      description: "The median Num Invitations across all instances within the grouping."
+      type: median
+      sql: ${num_invitations} ;;
+    }
+
+
+    measure: remaining_sum {
+      group_label: "Remaining Measures"
+      label: "Remaining (Sum)"
+      description: "The sum of Remaining across all instances within the grouping."
+      type: sum
+      sql: ${remaining} ;;
+    }
+
+    measure: remaining_avg {
+      group_label: "Remaining Measures"
+      label: "Remaining (Avg)"
+      description: "The average Remaining across all instances within the grouping."
+      type: average
+      sql: ${remaining} ;;
+    }
+
+    measure: remaining_median {
+      group_label: "Remaining Measures"
+      label: "Remaining (Med)"
+      description: "The median Remaining across all instances within the grouping."
+      type: median
+      sql: ${remaining} ;;
+    }
+
+
+
+  }

--- a/views/events/performance_events_duration.view.lkml
+++ b/views/events/performance_events_duration.view.lkml
@@ -1,4 +1,4 @@
-# This is the view file for the analytics.events.performance_events table.
+# This is the view file for the analytics.events.performance_events_duration table.
   view: performance_events_duration {
     sql_table_name: events.performance_events_duration ;;
     view_label: " Performance Events (Middle 90% Duration)"


### PR DESCRIPTION
Impact: Creating new view for performance_events analysis. We are calculating the 5th and 95th percentile values for duration and importing the data that is between them. 

Testing: Changes have been fully tested. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

