### PR TITLE
MM-43276/MM-43247/MM-43248 Adding fields for DAU/WAU/MAU calculations and Stripe Subscriptions

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -1995,6 +1995,14 @@ explore: server_daily_details {
   extends: [_base_account_core_explore]
   hidden: no
 
+  join: dates {
+    view_label: "Monthly Active Dates"
+    sql_on: ${user_events_telemetry.event_date}::date <= ${dates.date_date}::date AND ${user_events_telemetry.event_date}::date >= ${dates.date_date}::date - INTERVAL '30 DAYS' AND ${dates.date_date}::DATE <= CURRENT_DATE::DATE ;;
+    relationship: many_to_many
+    type: left_outer
+    fields: []
+  }
+
   join: account {
     view_label: "SF Account Details"
     sql_on: ${license_server_fact.customer_id} = ${account.sfid} ;;
@@ -2085,7 +2093,7 @@ explore: server_daily_details {
     view_label: "User Events"
     sql_on: ${user_events_telemetry.user_id} = ${server_daily_details.server_id} and ${user_events_telemetry.event_date} = ${server_daily_details.logging_date} ;;
     relationship: one_to_many
-    fields: [user_events_telemetry.post_count, user_events_telemetry.count1, user_events_telemetry.event_count, user_events_telemetry.thread_count, user_events_telemetry.members_added_to_team_sum,
+    fields: [user_events_telemetry.active_user_date_month, user_events_telemetry.daily_active_users, user_events_telemetry.monthly_active_users, user_events_telemetry.weekly_active_users, user_events_telemetry.post_count, user_events_telemetry.count1, user_events_telemetry.event_count, user_events_telemetry.thread_count, user_events_telemetry.members_added_to_team_sum,
       user_events_telemetry.members_removed_from_team_sum, user_events_telemetry.groups_removed_from_team_sum, user_events_telemetry.batch_add_members_sum, user_events_telemetry.user_actual_count, user_events_telemetry.event_count,
       user_events_telemetry.custom_emojis_added, user_events_telemetry.post_reaction_count, user_events_telemetry.groups_added_to_team_sum, user_events_telemetry.plugin_added_count, user_events_telemetry.plugin_updates_count]
   }

--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -2090,7 +2090,7 @@ explore: server_daily_details {
   }
 
   join: user_events_telemetry {
-    view_label: "User Events"
+    view_label: "User Events Telemetry"
     sql_on: ${user_events_telemetry.user_id} = ${server_daily_details.server_id} and ${user_events_telemetry.event_date} = ${server_daily_details.logging_date} ;;
     relationship: one_to_many
     fields: [user_events_telemetry.active_user_date_month, user_events_telemetry.daily_active_users, user_events_telemetry.monthly_active_users, user_events_telemetry.weekly_active_users, user_events_telemetry.post_count, user_events_telemetry.count1, user_events_telemetry.event_count, user_events_telemetry.thread_count, user_events_telemetry.members_added_to_team_sum,

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -1019,6 +1019,11 @@ view: user_events_telemetry {
     hidden: no
   }
 
+  dimension: password_requirements {
+    type: string
+    sql: ${TABLE}.password_requirements ;;
+    hidden: no
+  }
 
   # DIMENSION GROUPS/DATES
   dimension_group: original_timestamp {

--- a/views/mattermost/server_daily_details.view.lkml
+++ b/views/mattermost/server_daily_details.view.lkml
@@ -374,7 +374,7 @@ view: server_daily_details {
     description: "The server's IP Address."
     type: string
     sql: ${TABLE}.ip_address ;;
-    hidden: yes
+    hidden: no
   }
 
   dimension: grouping {
@@ -388,7 +388,7 @@ view: server_daily_details {
     description: "The 3 digit ISO code of the city or area that server resides in."
     type: string
     sql: ${TABLE}.location ;;
-    hidden: yes
+    hidden: no
   }
 
   dimension: active_user_count {

--- a/views/mattermost/server_daily_details.view.lkml
+++ b/views/mattermost/server_daily_details.view.lkml
@@ -374,7 +374,7 @@ view: server_daily_details {
     description: "The server's IP Address."
     type: string
     sql: ${TABLE}.ip_address ;;
-    hidden: no
+    hidden: yes
   }
 
   dimension: grouping {
@@ -388,7 +388,7 @@ view: server_daily_details {
     description: "The 3 digit ISO code of the city or area that server resides in."
     type: string
     sql: ${TABLE}.location ;;
-    hidden: no
+    hidden: yes
   }
 
   dimension: active_user_count {

--- a/views/stripe/subscriptions.view.lkml
+++ b/views/stripe/subscriptions.view.lkml
@@ -120,6 +120,11 @@ view: subscriptions {
     sql: ${TABLE}."QUANTITY" ;;
   }
 
+  dimension: plan {
+    type: string
+    sql: COALESCE(${TABLE}."PLAN":product, ${TABLE}."METADATA":current_product_id) ;;
+  }
+
   dimension_group: start {
     type: time
     timeframes: [


### PR DESCRIPTION
**Impact**: Adding fields for DAU/WAU/MAU calculations, Stripe Subscriptions, and unhiding IP address and Location fields.

a) DAU/WAU/MAU calculations:
 - https://mattermost.atlassian.net/browse/MM-43247
 - https://mattermost.atlassian.net/browse/MM-43248

b) Adding Plan field from Stripe Subscriptions, the same information can be derived from product_id, but I'd like to use the information from the field directly than deriving it.

~~c) Unhiding, IP Address and Location fields from server_daily_details for internal purposes. It isn't being used anywhere at the moment, but could be useful for future analyses.~~

d) Adding password_requirements field to user_events_telemetry for https://mattermost.atlassian.net/browse/MM-43276

**Testing** - Changes were tested and the visualization was added to the Growth Scorecard. The changes will be visible to the broader audience once this PR is merged.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

