### PR TITLE
MM - 43437 Adding weeks since and cloud server filter to focalboard retention

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -4030,6 +4030,20 @@ explore: focalboard_user_retention {
   label: " Focalboard User Retention"
   group_label: " Product: Boards"
   hidden: no
+
+  join: server_fact {
+    view_label: " Server Fact"
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${focalboard_user_retention.server_id} = ${server_fact.server_id} ;;
+  }
+
+  join: license_server_fact {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${focalboard_user_retention.server_id} = ${license_server_fact.server_id} ;;
+    fields: []
+  }
 }
 
 explore: arr_rollforward {

--- a/views/mattermost/focalboard_user_retention.view.lkml
+++ b/views/mattermost/focalboard_user_retention.view.lkml
@@ -10,6 +10,11 @@ view: focalboard_user_retention {
     sql: ROUND(MONTHS_BETWEEN(${max_original_timestamp_raw},${first_active_timestamp_raw}),0);;
   }
 
+  dimension: weeks_since_first_active {
+    type: number
+    sql: DATEDIFF(WEEK, ${first_active_timestamp_date}, ${max_original_timestamp_date});;
+  }
+
   dimension: month_name {
     type: string
     sql: ${first_active_timestamp_month_name} || ' - ' || ${first_active_timestamp_year};;


### PR DESCRIPTION
Impact: Adding weeks since and cloud server filter to focalboard retention.


Testing: Changes have been tested and viz has been added to the dashboard.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

