### PR TITLE
MM - 43788 , MM - 43437 New Looker changes for latest Analytics requests

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -3064,9 +3064,6 @@ explore: license_server_fact {
 
 }
 
-explore: subscriptions {
-  hidden: yes
-}
 
 explore: incident_response_events {
   description: "Contains all Incident Response events recorded by servers with Incident Response enabled. Including, but not limited to: Update/Create Playbook, Add/Remove Checklist Items, and Create/End Incident."
@@ -3995,6 +3992,18 @@ explore: user_retention {
   label: " User Retention"
   group_label: " Product: Messaging"
   hidden: no
+  fields: [ALL_FIELDS*, -user_events_telemetry.stripe_customer_email, -user_events_telemetry.stripe_customer_dns
+    , -user_events_telemetry.context_device_model, -user_events_telemetry.context_os_name, -user_events_telemetry.context_device_type
+    , -user_events_telemetry.context_os_version, -user_events_telemetry.context_device_manufacturer, -user_events_telemetry.active_user_date_date
+    , -user_events_telemetry.active_user_date_month, -user_events_telemetry.active_user_date_week, -user_events_telemetry.active_user_date_year
+    , -user_events_telemetry.active_user_date_fiscal_quarter, -user_events_telemetry.active_user_date_fiscal_year
+    , -user_events_telemetry.active_user_date_day_of_week
+    , -user_events_telemetry.active_user_date_fiscal_quarter_of_year
+    , -user_events_telemetry.active_user_date_day_of_month, -user_events_telemetry.active_user_date_month_name
+    , -user_events_telemetry.active_user_date_day_of_week_index
+    , -user_events_telemetry.active_user_date_day_of_year, -user_events_telemetry.active_user_date_week_of_year
+    , -user_events_telemetry.active_user_date_fiscal_month_num]
+
 
   join: server_fact {
     view_label: " Server Fact"
@@ -4024,6 +4033,15 @@ explore: user_retention {
     relationship: many_to_one
     sql_on: ${user_retention.server_id} = ${excludable_servers.server_id} ;;
   }
+
+  join: user_events_telemetry {
+    view_label: " User Events Telemetry"
+    type: left_outer
+    relationship: one_to_many
+    sql_on: ${user_retention.server_id} = ${user_events_telemetry.user_id}
+      and ${user_retention.user_id} = ${user_events_telemetry.user_actual_id} ;;
+  }
+
 }
 
 explore: focalboard_user_retention {
@@ -4056,4 +4074,38 @@ explore: arr_transactions {
   label: " ARR Transactions"
   group_label: " Finance"
   hidden: no
+}
+
+
+explore: invoices {
+  hidden: no
+  group_label: "Stripe"
+  description: "Contains all data from Stripe."
+  label: "Invoices (Stripe)"
+  view_label: "Invoices (Stripe)"
+
+  join: subscriptions_stripe {
+    from: subscriptions
+    view_label: "Subscriptions (Stripe)"
+    sql_on: ${invoices.subscription} = ${subscriptions_stripe.id} ;;
+    relationship: many_to_many
+  }
+
+  join: charges {
+    view_label: "Charges (Stripe)"
+    sql_on: ${charges.customer} = ${subscriptions_stripe.customer} ;;
+    relationship: many_to_many
+  }
+
+  join: invoice_line_items {
+    view_label: "Invoice Line Items (Stripe)"
+    relationship: many_to_many
+    sql_on: ${invoice_line_items.invoice} = ${invoices.id} ;;
+  }
+
+  join: customers {
+    view_label: "Customers (Stripe)"
+    sql_on: ${customers.id} = ${subscriptions_stripe.customer} ;;
+    relationship: many_to_many
+  }
 }

--- a/views/mattermost/focalboard_user_retention.view.lkml
+++ b/views/mattermost/focalboard_user_retention.view.lkml
@@ -15,6 +15,11 @@ view: focalboard_user_retention {
     sql: DATEDIFF(WEEK, ${first_active_timestamp_date}, ${max_original_timestamp_date});;
   }
 
+  dimension: days_since_first_active {
+    type: number
+    sql: DATEDIFF(DAY, ${first_active_timestamp_date}, ${max_original_timestamp_date});;
+  }
+
   dimension: month_name {
     type: string
     sql: ${first_active_timestamp_month_name} || ' - ' || ${first_active_timestamp_year};;

--- a/views/mattermost/server_daily_details.view.lkml
+++ b/views/mattermost/server_daily_details.view.lkml
@@ -277,7 +277,7 @@ view: server_daily_details {
     label: "   Logging"
     description: "The date the server details were logged."
     type: time
-    timeframes: [date, week, day_of_week, month, year, fiscal_quarter, fiscal_year]
+    timeframes: [date, week, day_of_week, month, year, fiscal_quarter, fiscal_year, raw]
     sql: ${TABLE}.date ;;
   }
 
@@ -1248,5 +1248,13 @@ view: server_daily_details {
     type: sum
     sql: ${events} ;;
     value_format_name: decimal_0
+  }
+
+  measure: upgrade_date {
+    group_label: "Server Events"
+    label: "Minimum Logging Date"
+    description: "Minimum Logging Date"
+    type: min
+    sql: ${logging_raw};;
   }
 }

--- a/views/mattermost/user_retention.view.lkml
+++ b/views/mattermost/user_retention.view.lkml
@@ -19,7 +19,8 @@ view: user_retention {
       week,
       month,
       quarter,
-      year
+      year,
+      hour_of_day
     ]
     sql: ${TABLE}."FIRST_ACTIVE_TIMESTAMP" ;;
   }

--- a/views/stripe/subscriptions.view.lkml
+++ b/views/stripe/subscriptions.view.lkml
@@ -1,6 +1,5 @@
 view: subscriptions {
-  sql_table_name: "STRIPE"."SUBSCRIPTIONS"
-    ;;
+  sql_table_name: "STRIPE"."SUBSCRIPTIONS";;
   drill_fields: [id]
 
   dimension: id {
@@ -122,7 +121,17 @@ view: subscriptions {
 
   dimension: plan {
     type: string
-    sql: COALESCE(${TABLE}."PLAN":product, ${TABLE}."METADATA":current_product_id) ;;
+    sql: COALESCE(${TABLE}."PLAN":product, ${TABLE}."METADATA":"current_product_id") ;;
+  }
+
+  dimension: cws_date_converted_to_paid{
+    type: date
+    sql: to_date(${TABLE}."METADATA":"cws-date-converted-to-paid") ;;
+  }
+
+  dimension: metadata {
+    type: string
+    sql: ${TABLE}."METADATA" ;;
   }
 
   dimension_group: start {

--- a/views/stripe/subscriptions.view.lkml
+++ b/views/stripe/subscriptions.view.lkml
@@ -121,7 +121,7 @@ view: subscriptions {
 
   dimension: plan {
     type: string
-    sql: COALESCE(${TABLE}."PLAN":product, ${TABLE}."METADATA":"current_product_id") ;;
+    sql: TRIM(COALESCE(${TABLE}."PLAN":product, ${TABLE}."METADATA":"current_product_id"),'"') ;;
   }
 
   dimension: cws_date_converted_to_paid{


### PR DESCRIPTION
Impact: These are a few additions for latest Analytics requests. 
1) MM-43437 Adding days since first active field for Focalboard retention charts.
2) MM-43788 Adding new explore which only captures Stripe tables, and doesn't join with BLAPI, as the current explore uses BLAPI as primary source and isn't capturing all the information from Stripe.
3) Adding new measure to server_daily_details to capture first upgrade date.
4) MM-42582 Joining user_events_telemetry to user_retention for performing New User drop-off analysis.

Testing: All these changes have been fully tested and will be visible after this is merged.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

