### PR TITLE
MM - 43662 Adding new measure to focalboard user retention

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -4062,6 +4062,12 @@ explore: focalboard_user_retention {
     sql_on: ${focalboard_user_retention.server_id} = ${license_server_fact.server_id} ;;
     fields: []
   }
+
+  join: excludable_servers {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${focalboard_user_retention.server_id} = ${excludable_servers.server_id} ;;
+  }
 }
 
 explore: arr_rollforward {

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -245,6 +245,23 @@ view: user_events_telemetry {
     hidden: no
   }
 
+  dimension: password_requirements_cloud_signup {
+    description: "Password Requirements (Cloud Signup)"
+    group_label: "Feature Flags"
+    type: string
+    sql: SPLIT_PART(${TABLE}.feature_flags,',',1) ;;
+    hidden: no
+  }
+
+  dimension: sso {
+    description: "SSO"
+    group_label: "Feature Flags"
+    type: string
+    sql: SPLIT_PART(${TABLE}.feature_flags,',',2) ;;
+    hidden: no
+  }
+
+
   dimension: context_timezone {
     label: "Timezone"
     description: ""

--- a/views/mattermost/focalboard_user_retention.view.lkml
+++ b/views/mattermost/focalboard_user_retention.view.lkml
@@ -121,4 +121,11 @@ view: focalboard_user_retention {
     sql:  COALESCE(COUNT(DISTINCT ${user_id}),0) ;;
     drill_fields: [id]
   }
+
+  measure: instance_count {
+    label: " Instance Count"
+    type: number
+    sql:  COALESCE(COUNT(DISTINCT ${server_id}),0) ;;
+    drill_fields: [id]
+  }
 }


### PR DESCRIPTION
Impact: Adding new measure Instance count to Focalboard view and adding excludable servers to the explore.

Adding new field Feature_flag and breaking it down as per the data in the field which are currently 
password requirement on cloud sign up and SSO to user events telemetry.

Testing: The visualizations were built and fully tested.

JIRA ticket - https://mattermost.atlassian.net/browse/MM-43662

JIRA ticket - https://mattermost.atlassian.net/browse/MM-43276

JIRA ticket - https://mattermost.atlassian.net/browse/MM-43494



<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

