### PR TITLE
Adding LDAP and Custom Group counts to server_daily_details_ext view

### DIFF
--- a/views/mattermost/server_daily_details_ext.view.lkml
+++ b/views/mattermost/server_daily_details_ext.view.lkml
@@ -2585,6 +2585,24 @@ view: server_daily_details_ext {
     hidden: no
   }
 
+  dimension: ldap_group_count {
+    label: "LDAP Group Count"
+    description: ""
+    type: number
+    group_label: "Groups Configuration"
+    sql: ${TABLE}.ldap_group_count ;;
+    hidden: no
+  }
+
+  dimension: custom_group_count {
+    label: "Custom Group Count"
+    description: ""
+    type: number
+    group_label: "Groups Configuration"
+    sql: ${TABLE}.custom_group_count ;;
+    hidden: no
+  }
+
   dimension: batch_size {
     description: ""
     type: number
@@ -6503,6 +6521,24 @@ view: server_daily_details_ext {
     type: sum
     group_label: " Groups Config: Groups Counts"
     sql: ${group_count_with_allow_reference};;
+    drill_fields: [logging_date, server_id, license_server_fact.customer_id, license_server_fact.customer_name, version, edition, days_since_first_telemetry_enabled, license_id, license_edition, license_users, user_count, active_user_count, system_admins, server_fact.first_active_date, server_fact.last_active_date]
+  }
+
+  measure: ldap_group_count_sum {
+    label: "Total LDAP Groups"
+    description: "Total LDAP Groups."
+    type: sum
+    group_label: " Groups Config: Groups Counts"
+    sql: ${ldap_group_count};;
+    drill_fields: [logging_date, server_id, license_server_fact.customer_id, license_server_fact.customer_name, version, edition, days_since_first_telemetry_enabled, license_id, license_edition, license_users, user_count, active_user_count, system_admins, server_fact.first_active_date, server_fact.last_active_date]
+  }
+
+  measure: custom_group_count_sum {
+    label: "Total Custom Groups"
+    description: "Total Custom Groups."
+    type: sum
+    group_label: " Groups Config: Groups Counts"
+    sql: ${custom_group_count};;
     drill_fields: [logging_date, server_id, license_server_fact.customer_id, license_server_fact.customer_name, version, edition, days_since_first_telemetry_enabled, license_id, license_edition, license_users, user_count, active_user_count, system_admins, server_fact.first_active_date, server_fact.last_active_date]
   }
 


### PR DESCRIPTION
Impact: Pull the new fields ldap_group_count and custom_group_count from server_daily_details_ext from the database into Looker.

Testing: The charts were built and will be visible to the broader audience once the this PR is merged.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

