### PR TITLE
Adding 14 day tier to days since user band

### DIFF
--- a/views/mattermost/server_daily_details_ext.view.lkml
+++ b/views/mattermost/server_daily_details_ext.view.lkml
@@ -5743,7 +5743,7 @@ view: server_daily_details_ext {
     description: "Displays the age in days of the server bucketed into groupings. Age is calculated as days between the first active user date (first date telemetry enabled) and logging date of the record."
     type: tier
     style: integer
-    tiers: [1,7,31,61,91,181,366,731]
+    tiers: [1,7,14,31,61,91,181,366,731]
     sql: ${days_since_first_telemetry_enabled} ;;
   }
 
@@ -5769,7 +5769,7 @@ view: server_daily_details_ext {
     description: "Displays the age in days of the server bucketed into groupings. Age is calculated as days between the first active date (first date telemetry enabled) and logging date of the record."
     type: tier
     style: integer
-    tiers: [1,7,31,61,91,181,366,731]
+    tiers: [1,7,14,31,61,91,181,366,731]
     sql: ${days_since_first_telemetry_enabled} ;;
   }
 


### PR DESCRIPTION
Impact: Adding 14 day tier to days since user bands for Workspace Retention charts for Cloud Freemium.

Testing: Changes were fully tested.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

