### PR TITLE
Fixed column reference for tasks_modified

### DIFF
--- a/views/incident_collaboration/incident_daily_details.view.lkml
+++ b/views/incident_collaboration/incident_daily_details.view.lkml
@@ -353,7 +353,7 @@ view: incident_daily_details {
     group_label: "All-Time Dimensions"
     description: ""
     type: number
-    sql: ${TABLE}.task_assignees_set_alltime ;;
+    sql: ${TABLE}.task_assignees_set ;;
     hidden: no
   }
 
@@ -361,7 +361,7 @@ view: incident_daily_details {
     group_label: "All-Time Dimensions"
     description: ""
     type: number
-    sql: ${TABLE}.task_states_modified_alltime ;;
+    sql: ${TABLE}.task_states_modified ;;
     hidden: no
   }
 

--- a/views/mattermost/server_fact.view.lkml
+++ b/views/mattermost/server_fact.view.lkml
@@ -158,6 +158,23 @@ view: server_fact {
     value_format_name: decimal_0
   }
 
+  dimension: retention_0day_flag {
+    label: "0-Day Retention"
+    group_label: "Telemetry Flags"
+    description: "Boolean indicating the instance was retained in the first 24 hours since their first active date. This metric is a flag indicating users performed events between hour 0 and 24 from the instance's first active timestamp."
+    type: yesno
+    sql: COALESCE(${TABLE}.retention_0day_flag, false) ;;
+  }
+
+  dimension: retention_0day_users {
+    label: " 0-Day Retained Users"
+    group_label: "User Event Dimensions"
+    description: "Number indicating the count of instance users that were retained in the first 24 hours since their first active date. This count indicates the users performed events between hour 0 and 24 hours from the instance's first active timestamp."
+    type: number
+    sql: COALESCE(${TABLE}.retention_0day_users, 0) ;;
+    value_format_name: decimal_0
+  }
+
 
   dimension_group: cloud_payment_method_added {
     label: "Cloud Payment Method Added"
@@ -1706,6 +1723,14 @@ view: server_fact {
     description: "The sum of registered users associated with all servers in the current grouping."
     type: number
     sql: sum(${max_registered_users}) ;;
+    drill_fields: [drill_set1*]
+  }
+
+  measure: retained_0day_user_sum {
+    label: "0-Day Retained Users"
+    description: "The sum of users that performed events within 0 & 24 hours of the instances first active timestamp across all servers in the current grouping."
+    type: number
+    sql: sum(${retention_0day_users}) ;;
     drill_fields: [drill_set1*]
   }
 

--- a/views/mattermost/user_retention.view.lkml
+++ b/views/mattermost/user_retention.view.lkml
@@ -47,6 +47,11 @@ view: user_retention {
     sql: ${TABLE}."RETENTION_1DAY_FLAG" ;;
   }
 
+  dimension: retention_0_day_flag {
+    type: yesno
+    sql: ${TABLE}."RETENTION_0DAY_FLAG" ;;
+  }
+
   dimension: retention_28_day_flag {
     type: yesno
     sql: ${TABLE}."RETENTION_28DAY_FLAG" ;;
@@ -91,6 +96,15 @@ view: user_retention {
     description: "The distinct count of Users."
     type: count_distinct
     sql:  ${user_id} ;;
+    drill_fields: [id]
+  }
+
+  measure: retention_0_day_users {
+    group_label: "User Co  unts"
+    label: "Retained Day 1 Users"
+    description: "The distinct count of servers/workspaces with Retained Day 1 Users marked true."
+    type: count_distinct
+    sql: CASE WHEN ${retention_0_day_flag} THEN ${user_id} ELSE NULL END;;
     drill_fields: [id]
   }
 


### PR DESCRIPTION
Impact: tasks_modified field was pointing to a field called tasks_modified_alltime which is incorrect, fixed the reference here.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

