### PR TITLE
Adding retention flags to user_events_telemetry explore

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -21,7 +21,10 @@ explore: user_events_telemetry {
     view_label: "Server Fact"
     sql_on: ${user_events_telemetry.user_id} = ${server_fact.server_id} ;;
     relationship: many_to_one
-    fields: [server_fact.retention_1day_flag, server_fact.installation_id, server_fact.first_server_version, server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.cloud_server, server_fact.registered_users_max, server_fact.max_registered_deactivated_users]
+    fields: [server_fact.retention_0day_flag, server_fact.retention_1day_flag, server_fact.retention_7day_flag,
+      server_fact.retention_14day_flag, server_fact.retention_28day_flag, server_fact.installation_id, server_fact.first_server_version,
+      server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.cloud_server,
+      server_fact.registered_users_max, server_fact.max_registered_deactivated_users]
   }
 
   join: excludable_servers {


### PR DESCRIPTION
Impact: Adding retention flags Day 0, 7, 14 and 28 to user_events_telemetry explore

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

