### PR TITLE
Removing customer filter from Clearbit data

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -2184,8 +2184,6 @@ explore: server_fact {
   join: cloud_clearbit {
     view_label: "Clearbit (Cloud Only)"
     sql_on: ${server_fact.server_id} = ${cloud_clearbit.server_id} ;;
-    sql_where: ${cloud_clearbit.company_name} NOT IN (SELECT DISTINCT customer_name
-    from blp.license_server_fact lsf join orgm.ACCOUNT a on lsf.account_sfid = a.sfid where type IN ('Customer','Customer (Attrited)')) ;;
     relationship: one_to_one
   }
 
@@ -2193,9 +2191,6 @@ explore: server_fact {
   join: onprem_clearbit {
     view_label: "Clearbit (Self-Managed Only)"
     sql_on: ${server_fact.server_id} = ${onprem_clearbit.server_id} ;;
-    sql_where: ${onprem_clearbit.company_name} NOT IN (SELECT DISTINCT customer_name
-    from blp.license_server_fact lsf join orgm.ACCOUNT a on lsf.account_sfid = a.sfid where type IN ('Customer','Customer (Attrited)'))
-    AND ${onprem_clearbit.company_name} != 'United States Air Force' ;;
     relationship: one_to_one
   }
 


### PR DESCRIPTION
Impact: Removing customer filter from Clearbit tables, which was added a while ago on Sales Request. By adding this filter we are unable to filter using our Salesforce Account Owners. Will revisit a different route to add the filter back. For the time being we need to be able to filter the dashboard on Account Owners.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

