### PR TITLE
Optimizing Looker performance on explore User Events Telemetry

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -3,6 +3,102 @@ include: "/**/**/*.view.lkml"
 fiscal_month_offset: -11
 week_start_day: sunday
 
+explore: user_events_telemetry {
+  label: "User Events Telemetry (Messaging)"
+  view_label: " User Events Telemetry (Messaging)"
+  group_label: " Product: Messaging"
+  description: "Contains all user-level usage events telemetry on the Mattermost platform across all clients and all customer data routing and processing platforms (segment & rudderstack) since 02/01/2019."
+
+  join: server_daily_details {
+    view_label: "Server Daily Details"
+    sql_on: ${user_events_telemetry.user_id} = ${server_daily_details.server_id} AND ${user_events_telemetry.event_date} = ${server_daily_details.logging_date} ;;
+    relationship: many_to_one
+    type: left_outer
+    fields: [server_daily_details.database_version, server_daily_details.database_version_major, server_daily_details.database_version_major_release, server_daily_details.server_version_major, server_daily_details.version, server_daily_details.edition]
+  }
+
+  join: server_fact {
+    view_label: "Server Fact"
+    sql_on: ${license_server_fact.server_id} = ${server_fact.server_id} ;;
+    relationship: many_to_one
+    fields: [server_fact.retention_0day_flag, server_fact.retention_1day_flag, server_fact.retention_7day_flag,
+      server_fact.retention_14day_flag, server_fact.retention_28day_flag, server_fact.retention_1week_flag, server_fact.retention_2week_flag, server_fact.retention_3week_flag,
+      server_fact.retention_4week_flag, server_fact.installation_id, server_fact.first_server_version,
+      server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.cloud_server,
+      server_fact.registered_users_max, server_fact.max_registered_deactivated_users, server_fact.server_count]
+  }
+
+  join: excludable_servers {
+    view_label: "Excludable Servers"
+    sql_on: ${server_fact.server_id} = ${excludable_servers.server_id} ;;
+    relationship: many_to_one
+    fields: [excludable_servers.reason]
+  }
+
+  join: user_agent_registry {
+    view_label: "User Agent Registry"
+    relationship: many_to_one
+    sql_on: ${user_events_telemetry.context_user_agent} = ${user_agent_registry.context_useragent} ;;
+    fields: [user_agent_registry.browser_version_major, user_agent_registry.bot, user_agent_registry.browser, user_agent_registry.browser_version, user_agent_registry.browser_w_version_major, user_agent_registry.browser_w_version, user_agent_registry.os_w_version, user_agent_registry.os_w_version_major]
+  }
+
+  join: subscriptions {
+    view_label: "Stripe Subscriptions"
+    relationship: one_to_one
+    sql_on: ${subscriptions.cws_installation} = ${server_fact.installation_id} ;;
+  }
+
+  join: customers {
+    view_label: "Stripe Subscription <> Customers"
+    relationship: one_to_one
+    sql_on: ${subscriptions.customer} = ${customers.id} ;;
+  }
+
+  join: portal_customers {
+    view_label: "Stripe Customers <> Portal"
+    from: customers
+    relationship: many_to_one
+    sql_on: ${portal_customers.cws_customer} = ${user_events_telemetry.context_traits_portal_customer_id} ;;
+  }
+
+  join: portal_subscriptions {
+    from: subscriptions
+    relationship: one_to_many
+    sql_on: ${portal_customers.id} = ${portal_subscriptions.customer} ;;
+    fields: []
+  }
+
+  join: license_server_fact {
+    view_label: "License Server Fact"
+    relationship: many_to_one
+    sql_on: COALESCE(${user_events_telemetry.portal_customer_id},${user_events_telemetry.context_traits_portal_customer_id})
+          = ${license_server_fact.customer_id}
+          LEFT JOIN blp.license_server_fact as license_server_fact2 ON
+          ${user_events_telemetry.userid} = license_server_fact2.server_id ;;
+  }
+
+  join: trial_requests {
+    sql_on: ${trial_requests.license_id} = ${license_server_fact.license_id} ;;
+    relationship: many_to_one
+    type: left_outer
+    fields: []
+  }
+
+  join: cloud_onboarding_flows {
+    relationship: many_to_one
+    sql_on: CASE WHEN ${user_events_telemetry.type} = 'pageview_getting_started_cloud' THEN  'pageview_getting_started' ELSE ${user_events_telemetry.type} END = ${cloud_onboarding_flows.type} AND ${user_events_telemetry.category} = ${cloud_onboarding_flows.category} ;;
+  }
+
+  join: dates {
+    sql_on: ${user_events_telemetry.event_date} <= ${dates.date_raw}
+      AND ${user_events_telemetry.event_date} >= ${dates.date_raw} - 30 AND ${dates.date_raw} <= CURRENT_DATE ;;
+    relationship: many_to_one
+    view_label: "Monthly Active Dates"
+    type: inner
+    fields: []
+  }
+}
+
 explore: focalboard_event_telemetry {
   label: "User Events Telemetry (Boards)"
   view_label: "User Events Telemetry (Boards)"
@@ -49,103 +145,5 @@ explore: focalboard_event_telemetry {
           AND ${focalboard_event_telemetry.user_id} = ${server_daily_details.server_id};;
     relationship: many_to_one
     fields: [account.name, account.sfid, account.total_current_arr]
-  }
-}
-
-
-explore: user_events_telemetry {
-  label: "User Events Telemetry (Messaging)"
-  view_label: " User Events Telemetry (Messaging)"
-  group_label: " Product: Messaging"
-  description: "Contains all user-level usage events telemetry on the Mattermost platform across all clients and all customer data routing and processing platforms (segment & rudderstack) since 02/01/2019."
-
-  join: server_daily_details {
-    view_label: " User Events Telemetry (Messaging)"
-    sql_on: ${user_events_telemetry.user_id} = ${server_daily_details.server_id} AND ${user_events_telemetry.event_date} = ${server_daily_details.logging_date} ;;
-    relationship: many_to_one
-    type: left_outer
-    fields: [server_daily_details.database_version, server_daily_details.database_version_major, server_daily_details.database_version_major_release, server_daily_details.server_version_major, server_daily_details.version, server_daily_details.edition]
-  }
-
-  join: server_fact {
-    view_label: "Server Fact"
-    sql_on: ${license_server_fact.server_id} = ${server_fact.server_id} ;;
-    relationship: many_to_one
-    fields: [server_fact.retention_0day_flag, server_fact.retention_1day_flag, server_fact.retention_7day_flag,
-      server_fact.retention_14day_flag, server_fact.retention_28day_flag, server_fact.retention_1week_flag, server_fact.retention_2week_flag, server_fact.retention_3week_flag,
-      server_fact.retention_4week_flag, server_fact.installation_id, server_fact.first_server_version,
-      server_fact.first_server_version_major, server_fact.first_server_edition, server_fact.cloud_server,
-      server_fact.registered_users_max, server_fact.max_registered_deactivated_users, server_fact.server_count]
-  }
-
-  join: excludable_servers {
-    view_label: " User Events Telemetry (Messaging)"
-    sql_on: ${user_events_telemetry.user_id} = ${excludable_servers.server_id} ;;
-    relationship: many_to_one
-    fields: [excludable_servers.reason]
-  }
-
-  join: user_agent_registry {
-    view_label: " User Events Telemetry (Messaging)"
-    relationship: many_to_one
-    sql_on: ${user_events_telemetry.context_user_agent} = ${user_agent_registry.context_useragent} ;;
-    fields: [user_agent_registry.browser_version_major, user_agent_registry.bot, user_agent_registry.browser, user_agent_registry.browser_version, user_agent_registry.browser_w_version_major, user_agent_registry.browser_w_version, user_agent_registry.os_w_version, user_agent_registry.os_w_version_major]
-  }
-
-  join: subscriptions {
-    view_label: "Stripe Subscriptions"
-    relationship: one_to_one
-    sql_on: ${subscriptions.cws_installation} = ${server_fact.installation_id} ;;
-  }
-
-  join: customers {
-    view_label: "Stripe Subscription <> Customers"
-    relationship: one_to_one
-    sql_on: ${subscriptions.customer} = ${customers.id} ;;
-  }
-
-  join: portal_customers {
-    view_label: "Stripe Customers <> Portal"
-    from: customers
-    relationship: many_to_one
-    sql_on: ${portal_customers.cws_customer} = ${user_events_telemetry.context_traits_portal_customer_id} ;;
-  }
-
-  join: portal_subscriptions {
-    from: subscriptions
-    relationship: one_to_many
-    sql_on: ${portal_customers.id} = ${portal_subscriptions.customer} ;;
-    fields: []
-  }
-
-  join: license_server_fact {
-    relationship: many_to_one
-    sql_on: CASE WHEN ${user_events_telemetry._dbt_source_relation2}
-    IN ('"ANALYTICS".EVENTS.CLOUD_PORTAL_PAGEVIEW_EVENTS', '"ANALYTICS".EVENTS.PORTAL_EVENTS')
-    THEN COALESCE(${user_events_telemetry.portal_customer_id},${user_events_telemetry.context_traits_portal_customer_id})
-    = ${license_server_fact.customer_id}
-    ELSE ${user_events_telemetry.user_id} = ${license_server_fact.server_id} END
-    ;;
-  }
-
-  join: trial_requests {
-    sql_on: ${trial_requests.license_id} = ${license_server_fact.license_id} ;;
-    relationship: many_to_one
-    type: left_outer
-    fields: []
-  }
-
-  join: cloud_onboarding_flows {
-    relationship: many_to_one
-    sql_on: CASE WHEN ${user_events_telemetry.type} = 'pageview_getting_started_cloud' THEN  'pageview_getting_started' ELSE ${user_events_telemetry.type} END = ${cloud_onboarding_flows.type} AND ${user_events_telemetry.category} = ${cloud_onboarding_flows.category} ;;
-  }
-
-  join: dates {
-    sql_on: ${user_events_telemetry.event_date} <= ${dates.date_raw}
-    AND ${user_events_telemetry.event_date} >= ${dates.date_raw} - 30 AND ${dates.date_raw} <= CURRENT_DATE ;;
-    relationship: many_to_one
-    view_label: "Monthly Active Dates"
-    type: inner
-    fields: []
   }
 }

--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -19,7 +19,7 @@ explore: user_events_telemetry {
 
   join: server_fact {
     view_label: "Server Fact"
-    sql_on: ${license_server_fact.server_id} = ${server_fact.server_id} ;;
+    sql_on: COALESCE(${license_server_fact.server_id},${license_server_fact2.server_id}) = ${server_fact.server_id} ;;
     relationship: many_to_one
     fields: [server_fact.retention_0day_flag, server_fact.retention_1day_flag, server_fact.retention_7day_flag,
       server_fact.retention_14day_flag, server_fact.retention_28day_flag, server_fact.retention_1week_flag, server_fact.retention_2week_flag, server_fact.retention_3week_flag,
@@ -30,7 +30,7 @@ explore: user_events_telemetry {
 
   join: excludable_servers {
     view_label: "Excludable Servers"
-    sql_on: ${server_fact.server_id} = ${excludable_servers.server_id} ;;
+    sql_on: ${user_events_telemetry.user_id} = ${excludable_servers.server_id} ;;
     relationship: many_to_one
     fields: [excludable_servers.reason]
   }
@@ -69,12 +69,18 @@ explore: user_events_telemetry {
   }
 
   join: license_server_fact {
+    from: license_server_fact
     view_label: "License Server Fact"
     relationship: many_to_one
+    sql_on: ${user_events_telemetry.user_id} = ${license_server_fact.server_id} ;;
+  }
+
+  join: license_server_fact2 {
+    from: license_server_fact
+    relationship: many_to_one
     sql_on: COALESCE(${user_events_telemetry.portal_customer_id},${user_events_telemetry.context_traits_portal_customer_id})
-          = ${license_server_fact.customer_id}
-          LEFT JOIN blp.license_server_fact as license_server_fact2 ON
-          ${user_events_telemetry.userid} = license_server_fact2.server_id ;;
+      = ${license_server_fact2.customer_id} ;;
+    fields: []
   }
 
   join: trial_requests {

--- a/views/blp/license_server_fact.view.lkml
+++ b/views/blp/license_server_fact.view.lkml
@@ -19,7 +19,7 @@ view: license_server_fact {
 
   dimension_group: last_telemetry {
     type: time
-    timeframes: [date, week, month, year, fiscal_year, fiscal_quarter]
+    timeframes: [raw, date, week, month, year, fiscal_year, fiscal_quarter]
     sql: ${TABLE}.last_telemetry_date ;;
     hidden: yes
   }
@@ -27,7 +27,7 @@ view: license_server_fact {
   dimension_group: last_server_telemetry {
     description: "The last time the server associated with the license sent telemetry."
     type: time
-    timeframes: [date, week, month, year, fiscal_year, fiscal_quarter]
+    timeframes: [raw, date, week, month, year, fiscal_year, fiscal_quarter]
     sql: ${TABLE}.last_server_telemetry ;;
   }
 
@@ -63,14 +63,14 @@ view: license_server_fact {
   }
 
   dimension: server_id {
-    description: ""
+    description: "Server ID"
     type: string
     sql: ${TABLE}.server_id ;;
     hidden: no
   }
 
   dimension: license_id {
-    description: ""
+    description: "License ID"
     type: string
     sql: ${TABLE}.license_id ;;
     hidden: no
@@ -85,7 +85,7 @@ view: license_server_fact {
 
   dimension: edition {
     label: "Edition"
-    description: ""
+    description: "Edition"
     type: string
     sql:  ${TABLE}.edition ;;
     # --IFF(NOT ${TABLE}.trial and ${TABLE}.edition IS NULL AND ${TABLE}.opportunity_sfid IS NOT NULL AND ${TABLE}.account_sfid IS NOT NULL, 'E20', COALESCE(${TABLE}.edition, 'E20 Trial')) ;;
@@ -130,7 +130,7 @@ view: license_server_fact {
   }
 
   dimension: license_email {
-    description: ""
+    description: "License Email"
     type: string
     sql: ${TABLE}.license_email ;;
     hidden: no
@@ -510,10 +510,10 @@ view: license_server_fact {
 
   # DIMENSION GROUPS/DATES
   dimension_group: issued {
-    label: "License Issued"
-    description: ""
+    label: "License Issued Date"
+    description: "License Issued Date"
     type: time
-    timeframes: [date, month, year, week, fiscal_quarter, fiscal_year]
+    timeframes: [raw, date, month, year, week, fiscal_quarter, fiscal_year]
     sql: ${TABLE}.issued_date ;;
     hidden: no
   }
@@ -524,10 +524,10 @@ view: license_server_fact {
   }
 
   dimension_group: start {
-    label: "License Start"
-    description: ""
+    label: "License Start Date"
+    description: "License Start Date"
     type: time
-    timeframes: [date, month, year, week, fiscal_quarter, fiscal_year]
+    timeframes: [raw, date, month, year, week, fiscal_quarter, fiscal_year]
     sql: ${TABLE}.start_date ;;
     hidden: no
   }
@@ -538,10 +538,10 @@ view: license_server_fact {
   }
 
   dimension_group: expire {
-    label: "License Expire"
-    description: ""
+    label: "License Expire Date"
+    description: "License Expire Dat"
     type: time
-    timeframes: [date, month, year, week, fiscal_quarter, fiscal_year]
+    timeframes: [raw, date, month, year, week, fiscal_quarter, fiscal_year]
     sql: ${TABLE}.expire_date ;;
     hidden: no
   }
@@ -570,7 +570,7 @@ view: license_server_fact {
   dimension_group: license_retired {
     description: "Value is retrieved via a windowing function that identifies the start date of the next license associated with the server, so there is no overlapping of license keys on Server logging dates."
     type: time
-    timeframes: [date, week, month, year, fiscal_year, fiscal_quarter]
+    timeframes: [raw, date, week, month, year, fiscal_year, fiscal_quarter]
     sql: ${TABLE}.license_retired_date ;;
     hidden: no
   }

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -1266,11 +1266,11 @@ view: user_events_telemetry {
   }
 
   dimension_group: received_at {
-  description: ""
+  description: "Received At"
   type: time
-  timeframes: [date, month, year]
+  timeframes: [raw, week, date, month, year, fiscal_quarter, fiscal_year]
     sql: ${TABLE}.received_at ;;
-    hidden: yes
+    hidden: no
   }
 
   dimension_group: channel_id_timestamp {


### PR DESCRIPTION
Impact: These changes are for Data Engineering team's internal efforts to improve Looker's performance. Looker creates a Cartesian join when the join condition specified is slow or complex. This has been eliminated with this PR. Also, improved other date fields in license_server_fact

Testing: These changes have been extensively tested multiple times and the performance difference has been huge. The testing took major part of the mana, since there are dashboards for Marketing which would break, since the join condition is fragile.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

