### PR TITLE
MM-46481 Add dimension for fresh field of channel_switch/team_switch events

### DIFF
--- a/views/events/performance_events.view.lkml
+++ b/views/events/performance_events.view.lkml
@@ -273,6 +273,13 @@ view_label: " Performance Events"
     type: number
     sql: ${TABLE}.longest_api_resource_duration ;;
   }
+  
+  dimension: fresh {
+    label: "Fresh"
+    description: "Whether or not a performance represents the first time something happened. Available for channel_switch and team_switch events."
+    type: string
+    sql: ${TABLE}.fresh ;;
+  }
 
   dimension: user_id {
     label: " Instance Id"


### PR DESCRIPTION
The `fresh` field tracks whether or not this is the first time we've switched to the given channel/team after opening the web app

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46481

