### PR TITLE
Fix request count for channel_switch/team_switch events

### DIFF
--- a/views/events/performance_events.view.lkml
+++ b/views/events/performance_events.view.lkml
@@ -257,7 +257,7 @@ view_label: " Performance Events"
     label: "Number of API requests"
     description: "The number of api requests made by the client for an event."
     type: number
-    sql: ${TABLE}.num_of_request ;;
+    sql: COALESCE(${TABLE}.num_of_request, ${TABLE}.request_count) ;;
   }
 
   dimension: maxAPIResourceSize {


### PR DESCRIPTION
Apparently when I added these, I didn't realize that the field I added to those events was `request_count` instead of `num_of_requests` which is used for `page_load` events. Instead of adding it as a separate measure, it seemed to make sense to combine them into one