### PR TITLE
Adding type to focalboard_user_retention

### DIFF
--- a/views/mattermost/focalboard_user_retention.view.lkml
+++ b/views/mattermost/focalboard_user_retention.view.lkml
@@ -26,6 +26,11 @@ view: focalboard_user_retention {
     order_by_field: first_active_timestamp_month
   }
 
+  dimension: type {
+    type: string
+    sql: ${TABLE}."TYPE";;
+  }
+
 
   dimension: id {
     primary_key: yes


### PR DESCRIPTION
Impact: Adding field type to focalboard_user_retention for comparison of user_retention based on different user activity.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

