### PR TITLE
MM-48663: Use raw for min/max dates

### DIFF
--- a/views/event_registry/daily_event_stats.view.lkml
+++ b/views/event_registry/daily_event_stats.view.lkml
@@ -71,13 +71,13 @@ view: daily_event_stats {
 
   measure: first_date {
     type:  min
-    sql: ${event_date_date} ;;
+    sql: ${event_date_raw} ;;
     description: "First date that this event was submitted"
   }
 
   measure: last_date {
     type:  max
-    sql: ${event_date_date} ;;
+    sql: ${event_date_raw} ;;
     description: "Last date that this event was submitted"
   }
 


### PR DESCRIPTION
#### Summary

Use `raw` field of date in order to avoid converting to string. This will make queries more efficient by avoiding unnecessary convertion. 