### PR TITLE
MM-49435: Added primary key for blapi invoices

### DIFF
--- a/views/blapi/invoices.view.lkml
+++ b/views/blapi/invoices.view.lkml
@@ -52,8 +52,8 @@ view: INVOICES {
     description: ""
     type: string
     sql: ${TABLE}.id ;;
-    hidden: no
     primary_key: yes
+    hidden: no
     link: {
       label: "Filter Invoice Disputes Dashboard"
       url: "/dashboards/224?Invoice%20ID={{ value }}"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a primary key to invoices view.

Issue - missing primary key on view `invoices` was leading to error while calculating sum.
Can't compute distinct value, no primary_key declared in view 'INVOICES'. (In field "INVOICES.total_sum")

Fix - Validated `id` to be primary key using following sql in snowflake.
SELECT
  COUNT(*),
  COUNT(DISTINCT id)
FROM
  analytics.blapi.invoices;
  
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-49435