### PR TITLE
Updating performance_events to point to marts table

### DIFF
--- a/views/events/performance_events.view.lkml
+++ b/views/events/performance_events.view.lkml
@@ -1,7 +1,7 @@
 
 # This is the view file for the analytics.events.performance_events table.
 view: performance_events {
-sql_table_name: events.performance_events ;;
+sql_table_name: mart_web_app.eg_performance_events ;;
 view_label: " Performance Events"
 
 
@@ -273,7 +273,7 @@ view_label: " Performance Events"
     type: number
     sql: ${TABLE}.longest_api_resource_duration ;;
   }
-  
+
   dimension: fresh {
     label: "Fresh"
     description: "Whether or not a performance represents the first time something happened. Available for channel_switch and team_switch events."
@@ -285,7 +285,7 @@ view_label: " Performance Events"
     label: " Instance Id"
     description: "The User Id (Instance ID) of the user performing the event."
     type: string
-    sql:COALESCE(${TABLE}.user_id, ${TABLE}.userid) ;;
+    sql: ${TABLE}.user_id ;;
   }
 
 
@@ -423,14 +423,6 @@ view_label: " Performance Events"
     description: "The Scheme Id of the user performing the event."
     type: string
     sql: ${TABLE}.scheme_id ;;
-  }
-
-
-  dimension: warnmetricid {
-    label: "Warnmetricid"
-    description: "The Warnmetricid attribute of the triggered event."
-    type: string
-    sql: ${TABLE}.warnmetricid ;;
   }
 
 


### PR DESCRIPTION
Impact: Updating performance_events to point to marts table and removing columns that do not apply.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

