### PR TITLE
Hotfix: Properly handle event name from event name/type combination

### DIFF
--- a/views/event_registry/dim_events.view.lkml
+++ b/views/event_registry/dim_events.view.lkml
@@ -45,8 +45,8 @@ view: dim_events {
 
   dimension: normalized_event_type {
     type: string
-    sql: COALESCE(${event_type}, ${event_name}) ;;
-    description: "Either the type of event or its name if type is not present."
+    sql: case when ${event_name} = 'event' and ${event_type} is not null then ${event_type} else ${event_name} end;;
+    description: "The type of event if event name is a catch-all name (like event), else the event's name."
   }
 
   dimension: source {


### PR DESCRIPTION
#### Summary

Normalized event name is used to reconcile data from javascript events. Those events always define event name as `event`. In those cases `type` needs to be preferred. 

Current logic was always preferring `type`, no matter what the `event` name was. This created a few issues in other sources where `type` also existed, but with different semantics. An example is the apps framework related events.

The current PR makes sure that name is adjusted to type ONLY if event name is `event`.
