### PR TITLE
MM-48421 new DAU/MAU models

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -1,0 +1,14 @@
+connection: "snowflake"
+
+include: "/views/marts/product/*.view.lkml"
+
+explore: fct_active_users {
+  label: "Telemetry Active Users"
+  group_label: "[New] Active Users"
+
+  join: dim_daily_server_info {
+    relationship: one_to_many
+    type: left_outer # Telemetry might not have been submitted from server at a given time
+    sql_on: ${fct_active_users.daily_server_id} = ${dim_daily_server_info.daily_server_id} ;;
+  }
+}

--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -7,7 +7,7 @@ explore: fct_active_users {
   group_label: "[New] Active Users"
 
   join: dim_daily_server_info {
-    relationship: one_to_many
+    relationship: one_to_one
     type: left_outer # Telemetry might not have been submitted from server at a given time
     sql_on: ${fct_active_users.daily_server_id} = ${dim_daily_server_info.daily_server_id} ;;
   }

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -1,5 +1,5 @@
 view: dim_daily_server_info {
-  sql_table_name: "MART_PRODUCT"."DIM_DAILY_SERVER_INFO" ;;
+  sql_table_name: "mart_product"."dim_daily_server_info" ;;
   label: "Daily Server Info"
 
   ##
@@ -8,14 +8,14 @@ view: dim_daily_server_info {
 
   dimension: daily_server_id {
     type: string
-    sql: ${TABLE}."DAILY_SERVER_ID" ;;
+    sql: ${TABLE}."daily_derver_id" ;;
     primary_key: yes
     hidden: yes
   }
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."SERVER_ID" ;;
+    sql: ${TABLE}."server_id" ;;
     label: "Server ID"
     description: "The Server's ID"
   }
@@ -25,7 +25,7 @@ view: dim_daily_server_info {
     timeframes: [raw, date, week, month, quarter, year]
     convert_tz: no
     datatype: date
-    sql: ${TABLE}."ACTIVITY_DATE" ;;
+    sql: ${TABLE}."activity_date" ;;
     label: "Server Telemetry Activity"  # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
   }
@@ -37,7 +37,7 @@ view: dim_daily_server_info {
 
   dimension: database_type {
     type: string
-    sql: ${TABLE}."DATABASE_TYPE" ;;
+    sql: ${TABLE}."database_type" ;;
     label: "Database Type"
     description: "The type of the database"
     view_label: "- Server Metadata"
@@ -45,7 +45,7 @@ view: dim_daily_server_info {
 
   dimension: database_version {
     type: string
-    sql: ${TABLE}."DATABASE_VERSION" ;;
+    sql: ${TABLE}."database_version" ;;
     label: "Database Version"
     description: "The version of the database"
     view_label: "- Server Metadata"
@@ -53,7 +53,7 @@ view: dim_daily_server_info {
 
   dimension: installation_id {
     type: string
-    sql: ${TABLE}."INSTALLATION_ID" ;;
+    sql: ${TABLE}."installation_id" ;;
     label: "Installation ID"
     description: "The server's installation ID (if any)"
     view_label: "- Server Metadata"
@@ -61,7 +61,7 @@ view: dim_daily_server_info {
 
   dimension: installation_type {
     type: string
-    sql: ${TABLE}."INSTALLATION_TYPE" ;;
+    sql: ${TABLE}."installation_type" ;;
     label: "Installation type"
     description: "The server's installation type (if any)"
     view_label: "- Server Metadata"
@@ -69,7 +69,7 @@ view: dim_daily_server_info {
 
   dimension: is_cloud {
     type: yesno
-    sql: ${TABLE}."IS_CLOUD" ;;
+    sql: ${TABLE}."is_cloud" ;;
     label: "Is Cloud?"
     description: "Whether this is a cloud server"
     view_label: "- Server Metadata"
@@ -77,7 +77,7 @@ view: dim_daily_server_info {
 
   dimension: is_enterprise_ready {
     type: string
-    sql: ${TABLE}."IS_ENTERPRISE_READY" ;;
+    sql: ${TABLE}."is_enterprise_ready" ;;
     label: "Is Enterprise Ready?"
     description: "Whether this is an enterprise ready server"
     view_label: "- Server Metadata"
@@ -85,7 +85,7 @@ view: dim_daily_server_info {
 
   dimension: operating_system {
     type: string
-    sql: ${TABLE}."OPERATING_SYSTEM" ;;
+    sql: ${TABLE}."operating_system" ;;
     label: "Operating System"
     description: "The OS the server is installed on"
     view_label: "- Server Metadata"
@@ -93,7 +93,7 @@ view: dim_daily_server_info {
 
   dimension: server_ip {
     type: string
-    sql: ${TABLE}."SERVER_IP" ;;
+    sql: ${TABLE}."server_ip" ;;
     label: "IP Address"
     description: "The server's IP address"
     view_label: "- Server Metadata"
@@ -105,35 +105,35 @@ view: dim_daily_server_info {
 
   dimension: version_full {
     type: string
-    sql: ${TABLE}."VERSION_FULL" ;;
+    sql: ${TABLE}."version_full" ;;
     label: "Server Version"
     view_label: "- Server Version"
   }
 
   dimension: version_major {
     type: string
-    sql: ${TABLE}."VERSION_MAJOR" ;;
+    sql: ${TABLE}."version_major" ;;
     label: "Major Version"
     view_label: "- Server Version"
   }
 
   dimension: version_minor {
     type: string
-    sql: ${TABLE}."VERSION_MINOR" ;;
+    sql: ${TABLE}."version_minor" ;;
     label: "Minor Version"
     view_label: "- Server Version"
   }
 
   dimension: version_patch {
     type: string
-    sql: ${TABLE}."VERSION_PATCH" ;;
+    sql: ${TABLE}."version_patch" ;;
     label: "Patch Version"
     view_label: "- Server Version"
   }
 
   dimension: count_reported_versions {
     type: number
-    sql: ${TABLE}."COUNT_REPORTED_VERSIONS" ;;
+    sql: ${TABLE}."count_reported_versions" ;;
     label: "Number of reported versions"
     view_label: "- Server Version"
   }
@@ -144,7 +144,7 @@ view: dim_daily_server_info {
 
   dimension: has_diagnostics_data {
     type: yesno
-    sql: ${TABLE}."HAS_DIAGNOSTICS_DATA" ;;
+    sql: ${TABLE}."has_diagnostics_data" ;;
     label: "Has diagnostics data?"
     description: " Whether the server queried the security update endpoint at the current date"
     view_label: "- Data Source Info"
@@ -152,7 +152,7 @@ view: dim_daily_server_info {
 
   dimension: has_legacy_telemetry_data {
     type: yesno
-    sql: ${TABLE}."HAS_LEGACY_TELEMETRY_DATA" ;;
+    sql: ${TABLE}."has_legacy_telemetry_data" ;;
     label: "Has legacy telemetry"
     description: "Whether telemetry data were reported from legacy telemetry pipeline (Segment) at the current date"
     view_label: "- Data Source Info"
@@ -160,7 +160,7 @@ view: dim_daily_server_info {
 
   dimension: has_telemetry_data {
     type: yesno
-    sql: ${TABLE}."HAS_TELEMETRY_DATA" ;;
+    sql: ${TABLE}."has_telemetry_data" ;;
     label: "Has telemetry?"
     description: "Whether telemetry data were reported from telemetry pipeline (Rudderstack) at the current date/"
     view_label: "- Data Source Info"

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -26,9 +26,8 @@ view: dim_daily_server_info {
     convert_tz: no
     datatype: date
     sql: ${TABLE}."ACTIVITY_DATE" ;;
-    label: "Server Telemetry Activity date"
+    label: "Server Telemetry Activity"  # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
-
   }
 
   ##
@@ -41,6 +40,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."DATABASE_TYPE" ;;
     label: "Database Type"
     description: "The type of the database"
+    view_label: "- Server Metadata"
   }
 
   dimension: database_version {
@@ -48,6 +48,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."DATABASE_VERSION" ;;
     label: "Database Version"
     description: "The version of the database"
+    view_label: "- Server Metadata"
   }
 
   dimension: installation_id {
@@ -55,6 +56,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."INSTALLATION_ID" ;;
     label: "Installation ID"
     description: "The server's installation ID (if any)"
+    view_label: "- Server Metadata"
   }
 
   dimension: installation_type {
@@ -62,6 +64,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."INSTALLATION_TYPE" ;;
     label: "Installation type"
     description: "The server's installation type (if any)"
+    view_label: "- Server Metadata"
   }
 
   dimension: is_cloud {
@@ -69,6 +72,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."IS_CLOUD" ;;
     label: "Is Cloud?"
     description: "Whether this is a cloud server"
+    view_label: "- Server Metadata"
   }
 
   dimension: is_enterprise_ready {
@@ -76,6 +80,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."IS_ENTERPRISE_READY" ;;
     label: "Is Enterprise Ready?"
     description: "Whether this is an enterprise ready server"
+    view_label: "- Server Metadata"
   }
 
   dimension: operating_system {
@@ -83,6 +88,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."OPERATING_SYSTEM" ;;
     label: "Operating System"
     description: "The OS the server is installed on"
+    view_label: "- Server Metadata"
   }
 
   dimension: server_ip {
@@ -90,6 +96,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."SERVER_IP" ;;
     label: "IP Address"
     description: "The server's IP address"
+    view_label: "- Server Metadata"
   }
 
   ###
@@ -100,37 +107,35 @@ view: dim_daily_server_info {
     type: string
     sql: ${TABLE}."VERSION_FULL" ;;
     label: "Server Version"
-    view_label: "Version"
+    view_label: "- Server Version"
   }
 
   dimension: version_major {
     type: string
     sql: ${TABLE}."VERSION_MAJOR" ;;
     label: "Major Version"
-    view_label: "Version"
-
+    view_label: "- Server Version"
   }
 
   dimension: version_minor {
     type: string
     sql: ${TABLE}."VERSION_MINOR" ;;
     label: "Minor Version"
-    view_label: "Version"
+    view_label: "- Server Version"
   }
 
   dimension: version_patch {
     type: string
     sql: ${TABLE}."VERSION_PATCH" ;;
     label: "Patch Version"
-    view_label: "Version"
+    view_label: "- Server Version"
   }
-
 
   dimension: count_reported_versions {
     type: number
     sql: ${TABLE}."COUNT_REPORTED_VERSIONS" ;;
     label: "Number of reported versions"
-    view_label: "Version"
+    view_label: "- Server Version"
   }
 
   ###
@@ -142,7 +147,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."HAS_DIAGNOSTICS_DATA" ;;
     label: "Has diagnostics data?"
     description: " Whether the server queried the security update endpoint at the current date"
-    view_label: "Data Source Info"
+    view_label: "- Data Source Info"
   }
 
   dimension: has_legacy_telemetry_data {
@@ -150,7 +155,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."HAS_LEGACY_TELEMETRY_DATA" ;;
     label: "Has legacy telemetry"
     description: "Whether telemetry data were reported from legacy telemetry pipeline (Segment) at the current date"
-    view_label: "Data Source Info"
+    view_label: "- Data Source Info"
   }
 
   dimension: has_telemetry_data {
@@ -158,7 +163,7 @@ view: dim_daily_server_info {
     sql: ${TABLE}."HAS_TELEMETRY_DATA" ;;
     label: "Has telemetry?"
     description: "Whether telemetry data were reported from telemetry pipeline (Rudderstack) at the current date/"
-    view_label: "Data Source Info"
+    view_label: "- Data Source Info"
   }
 
   measure: number_of_servers {

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -1,5 +1,5 @@
 view: dim_daily_server_info {
-  sql_table_name: "MART_PRODUCT"."dim_daily_server_info" ;;
+  sql_table_name: "MART_PRODUCT"."DIM_DAILY_SERVER_INFO" ;;
   label: "Daily Server Info"
 
   ##

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -8,14 +8,14 @@ view: dim_daily_server_info {
 
   dimension: daily_server_id {
     type: string
-    sql: ${TABLE}."daily_derver_id" ;;
+    sql: ${TABLE}.daily_derver_id ;;
     primary_key: yes
     hidden: yes
   }
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."server_id" ;;
+    sql: ${TABLE}.server_id ;;
     label: "Server ID"
     description: "The Server's ID"
   }
@@ -25,7 +25,7 @@ view: dim_daily_server_info {
     timeframes: [raw, date, week, month, quarter, year]
     convert_tz: no
     datatype: date
-    sql: ${TABLE}."activity_date" ;;
+    sql: ${TABLE}.activity_date ;;
     label: "Server Telemetry Activity"  # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
   }
@@ -37,7 +37,7 @@ view: dim_daily_server_info {
 
   dimension: database_type {
     type: string
-    sql: ${TABLE}."database_type" ;;
+    sql: ${TABLE}.database_type ;;
     label: "Database Type"
     description: "The type of the database"
     view_label: "- Server Metadata"
@@ -45,7 +45,7 @@ view: dim_daily_server_info {
 
   dimension: database_version {
     type: string
-    sql: ${TABLE}."database_version" ;;
+    sql: ${TABLE}.database_version ;;
     label: "Database Version"
     description: "The version of the database"
     view_label: "- Server Metadata"
@@ -53,7 +53,7 @@ view: dim_daily_server_info {
 
   dimension: installation_id {
     type: string
-    sql: ${TABLE}."installation_id" ;;
+    sql: ${TABLE}.installation_id ;;
     label: "Installation ID"
     description: "The server's installation ID (if any)"
     view_label: "- Server Metadata"
@@ -61,7 +61,7 @@ view: dim_daily_server_info {
 
   dimension: installation_type {
     type: string
-    sql: ${TABLE}."installation_type" ;;
+    sql: ${TABLE}.installation_type ;;
     label: "Installation type"
     description: "The server's installation type (if any)"
     view_label: "- Server Metadata"
@@ -69,7 +69,7 @@ view: dim_daily_server_info {
 
   dimension: is_cloud {
     type: yesno
-    sql: ${TABLE}."is_cloud" ;;
+    sql: ${TABLE}.is_cloud ;;
     label: "Is Cloud?"
     description: "Whether this is a cloud server"
     view_label: "- Server Metadata"
@@ -77,7 +77,7 @@ view: dim_daily_server_info {
 
   dimension: is_enterprise_ready {
     type: string
-    sql: ${TABLE}."is_enterprise_ready" ;;
+    sql: ${TABLE}.is_enterprise_ready ;;
     label: "Is Enterprise Ready?"
     description: "Whether this is an enterprise ready server"
     view_label: "- Server Metadata"
@@ -85,7 +85,7 @@ view: dim_daily_server_info {
 
   dimension: operating_system {
     type: string
-    sql: ${TABLE}."operating_system" ;;
+    sql: ${TABLE}.operating_system ;;
     label: "Operating System"
     description: "The OS the server is installed on"
     view_label: "- Server Metadata"
@@ -93,7 +93,7 @@ view: dim_daily_server_info {
 
   dimension: server_ip {
     type: string
-    sql: ${TABLE}."server_ip" ;;
+    sql: ${TABLE}.server_ip ;;
     label: "IP Address"
     description: "The server's IP address"
     view_label: "- Server Metadata"
@@ -105,35 +105,35 @@ view: dim_daily_server_info {
 
   dimension: version_full {
     type: string
-    sql: ${TABLE}."version_full" ;;
+    sql: ${TABLE}.version_full ;;
     label: "Server Version"
     view_label: "- Server Version"
   }
 
   dimension: version_major {
     type: string
-    sql: ${TABLE}."version_major" ;;
+    sql: ${TABLE}.version_major ;;
     label: "Major Version"
     view_label: "- Server Version"
   }
 
   dimension: version_minor {
     type: string
-    sql: ${TABLE}."version_minor" ;;
+    sql: ${TABLE}.version_minor ;;
     label: "Minor Version"
     view_label: "- Server Version"
   }
 
   dimension: version_patch {
     type: string
-    sql: ${TABLE}."version_patch" ;;
+    sql: ${TABLE}.version_patch ;;
     label: "Patch Version"
     view_label: "- Server Version"
   }
 
   dimension: count_reported_versions {
     type: number
-    sql: ${TABLE}."count_reported_versions" ;;
+    sql: ${TABLE}.count_reported_versions ;;
     label: "Number of reported versions"
     view_label: "- Server Version"
   }
@@ -144,7 +144,7 @@ view: dim_daily_server_info {
 
   dimension: has_diagnostics_data {
     type: yesno
-    sql: ${TABLE}."has_diagnostics_data" ;;
+    sql: ${TABLE}.has_diagnostics_data ;;
     label: "Has diagnostics data?"
     description: " Whether the server queried the security update endpoint at the current date"
     view_label: "- Data Source Info"
@@ -152,7 +152,7 @@ view: dim_daily_server_info {
 
   dimension: has_legacy_telemetry_data {
     type: yesno
-    sql: ${TABLE}."has_legacy_telemetry_data" ;;
+    sql: ${TABLE}.has_legacy_telemetry_data ;;
     label: "Has legacy telemetry"
     description: "Whether telemetry data were reported from legacy telemetry pipeline (Segment) at the current date"
     view_label: "- Data Source Info"
@@ -160,7 +160,7 @@ view: dim_daily_server_info {
 
   dimension: has_telemetry_data {
     type: yesno
-    sql: ${TABLE}."has_telemetry_data" ;;
+    sql: ${TABLE}.has_telemetry_data ;;
     label: "Has telemetry?"
     description: "Whether telemetry data were reported from telemetry pipeline (Rudderstack) at the current date/"
     view_label: "- Data Source Info"

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -1,0 +1,168 @@
+view: dim_daily_server_info {
+  sql_table_name: "MART_PRODUCT"."DIM_DAILY_SERVER_INFO" ;;
+  label: "Daily Server Info"
+
+  ##
+  ## ID
+  ##
+
+  dimension: daily_server_id {
+    type: string
+    sql: ${TABLE}."DAILY_SERVER_ID" ;;
+    primary_key: yes
+    hidden: yes
+  }
+
+  dimension: server_id {
+    type: string
+    sql: ${TABLE}."SERVER_ID" ;;
+    label: "Server ID"
+    description: "The Server's ID"
+  }
+
+  dimension_group: activity {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}."ACTIVITY_DATE" ;;
+    label: "Server Telemetry Activity date"
+    description: "The date current data were captured at"
+
+  }
+
+  ##
+  ## Dimensions
+  ##
+
+
+  dimension: database_type {
+    type: string
+    sql: ${TABLE}."DATABASE_TYPE" ;;
+    label: "Database Type"
+    description: "The type of the database"
+  }
+
+  dimension: database_version {
+    type: string
+    sql: ${TABLE}."DATABASE_VERSION" ;;
+    label: "Database Version"
+    description: "The version of the database"
+  }
+
+  dimension: installation_id {
+    type: string
+    sql: ${TABLE}."INSTALLATION_ID" ;;
+    label: "Installation ID"
+    description: "The server's installation ID (if any)"
+  }
+
+  dimension: installation_type {
+    type: string
+    sql: ${TABLE}."INSTALLATION_TYPE" ;;
+    label: "Installation type"
+    description: "The server's installation type (if any)"
+  }
+
+  dimension: is_cloud {
+    type: yesno
+    sql: ${TABLE}."IS_CLOUD" ;;
+    label: "Is Cloud?"
+    description: "Whether this is a cloud server"
+  }
+
+  dimension: is_enterprise_ready {
+    type: string
+    sql: ${TABLE}."IS_ENTERPRISE_READY" ;;
+    label: "Is Enterprise Ready?"
+    description: "Whether this is an enterprise ready server"
+  }
+
+  dimension: operating_system {
+    type: string
+    sql: ${TABLE}."OPERATING_SYSTEM" ;;
+    label: "Operating System"
+    description: "The OS the server is installed on"
+  }
+
+  dimension: server_ip {
+    type: string
+    sql: ${TABLE}."SERVER_IP" ;;
+    label: "IP Address"
+    description: "The server's IP address"
+  }
+
+  ###
+  ### Version Information
+  ###
+
+  dimension: version_full {
+    type: string
+    sql: ${TABLE}."VERSION_FULL" ;;
+    label: "Server Version"
+    view_label: "Version"
+  }
+
+  dimension: version_major {
+    type: string
+    sql: ${TABLE}."VERSION_MAJOR" ;;
+    label: "Major Version"
+    view_label: "Version"
+
+  }
+
+  dimension: version_minor {
+    type: string
+    sql: ${TABLE}."VERSION_MINOR" ;;
+    label: "Minor Version"
+    view_label: "Version"
+  }
+
+  dimension: version_patch {
+    type: string
+    sql: ${TABLE}."VERSION_PATCH" ;;
+    label: "Patch Version"
+    view_label: "Version"
+  }
+
+
+  dimension: count_reported_versions {
+    type: number
+    sql: ${TABLE}."COUNT_REPORTED_VERSIONS" ;;
+    label: "Number of reported versions"
+    view_label: "Version"
+  }
+
+  ###
+  ### Data Source info
+  ###
+
+  dimension: has_diagnostics_data {
+    type: yesno
+    sql: ${TABLE}."HAS_DIAGNOSTICS_DATA" ;;
+    label: "Has diagnostics data?"
+    description: " Whether the server queried the security update endpoint at the current date"
+    view_label: "Data Source Info"
+  }
+
+  dimension: has_legacy_telemetry_data {
+    type: yesno
+    sql: ${TABLE}."HAS_LEGACY_TELEMETRY_DATA" ;;
+    label: "Has legacy telemetry"
+    description: "Whether telemetry data were reported from legacy telemetry pipeline (Segment) at the current date"
+    view_label: "Data Source Info"
+  }
+
+  dimension: has_telemetry_data {
+    type: yesno
+    sql: ${TABLE}."HAS_TELEMETRY_DATA" ;;
+    label: "Has telemetry?"
+    description: "Whether telemetry data were reported from telemetry pipeline (Rudderstack) at the current date/"
+    view_label: "Data Source Info"
+  }
+
+  measure: number_of_servers {
+    type: count
+    label: "Count"
+  }
+}

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -8,7 +8,7 @@ view: dim_daily_server_info {
 
   dimension: daily_server_id {
     type: string
-    sql: ${TABLE}.daily_derver_id ;;
+    sql: ${TABLE}.daily_server_id ;;
     primary_key: yes
     hidden: yes
   }

--- a/views/marts/product/dim_daily_server_info.view.lkml
+++ b/views/marts/product/dim_daily_server_info.view.lkml
@@ -1,5 +1,5 @@
 view: dim_daily_server_info {
-  sql_table_name: "mart_product"."dim_daily_server_info" ;;
+  sql_table_name: "MART_PRODUCT"."dim_daily_server_info" ;;
   label: "Daily Server Info"
 
   ##

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -1,6 +1,6 @@
 # The name of this view in Looker is "Dim Excludable Servers"
 view: dim_excludable_servers {
-  sql_table_name: "mart_product"."dim_excludable_servers" ;;
+  sql_table_name: "MART_PRODUCT"."dim_excludable_servers" ;;
 
   label: "Excludable Servers"
 

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -1,6 +1,6 @@
 # The name of this view in Looker is "Dim Excludable Servers"
 view: dim_excludable_servers {
-  sql_table_name: "MART_PRODUCT"."dim_excludable_servers" ;;
+  sql_table_name: "MART_PRODUCT"."DIM_EXCLUDABLE_SERVERS" ;;
 
   label: "Excludable Servers"
 

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -1,0 +1,20 @@
+# The name of this view in Looker is "Dim Excludable Servers"
+view: dim_excludable_servers {
+  sql_table_name: "MART_PRODUCT"."DIM_EXCLUDABLE_SERVERS" ;;
+
+  label: "Excludable Servers"
+
+  dimension: server_id {
+    type: string
+    sql: ${TABLE}."SERVER_ID" ;;
+    primary_key: yes
+    label: " The server's ID"
+  }
+
+  dimension: reasons {
+    type: string
+    sql: ${TABLE}."REASONS" ;;
+    label: "List of reasons this server is considered for exclusion."
+  }
+
+}

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -6,14 +6,14 @@ view: dim_excludable_servers {
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."server_id" ;;
+    sql: ${TABLE}.server_id ;;
     primary_key: yes
     label: " The server's ID"
   }
 
   dimension: reasons {
     type: string
-    sql: ${TABLE}."reasons" ;;
+    sql: ${TABLE}.reasons ;;
     label: "List of reasons this server is considered for exclusion."
   }
 

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -1,19 +1,19 @@
 # The name of this view in Looker is "Dim Excludable Servers"
 view: dim_excludable_servers {
-  sql_table_name: "MART_PRODUCT"."DIM_EXCLUDABLE_SERVERS" ;;
+  sql_table_name: "mart_product"."dim_excludable_servers" ;;
 
   label: "Excludable Servers"
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."SERVER_ID" ;;
+    sql: ${TABLE}."server_id" ;;
     primary_key: yes
     label: " The server's ID"
   }
 
   dimension: reasons {
     type: string
-    sql: ${TABLE}."REASONS" ;;
+    sql: ${TABLE}."reasons" ;;
     label: "List of reasons this server is considered for exclusion."
   }
 

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -1,0 +1,226 @@
+view: fct_active_users {
+
+  sql_table_name: "MART_PRODUCT"."FCT_ACTIVE_USERS" ;;
+  label: "Telemetry Active Users"
+
+  ###
+  ### IDs and dates
+  ###
+
+  dimension: daily_server_id {
+    type: string
+    sql: ${TABLE}."DAILY_SERVER_ID" ;;
+    primary_key: yes
+    hidden: yes
+  }
+
+  dimension: server_id {
+    type: string
+    sql: ${TABLE}."SERVER_ID" ;;
+    label: "Server ID"
+    description: "The server's ID"
+  }
+
+  dimension_group: activity {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}."ACTIVITY_DATE" ;;
+    label: "Server Telemetry Activity date"
+    description: "The date current data were captured at"
+  }
+
+  ###
+  ### DAU
+  ###
+
+  dimension: daily_active_users {
+    type: number
+    sql: ${TABLE}."DAILY_ACTIVE_USERS" ;;
+    label: "DAU"
+    description: "Number of unique users for current date"
+    view_label: "DAU"
+  }
+
+  measure: total_daily_active_users {
+    type: sum
+    sql: ${daily_active_users} ;;
+    label: "Total DAU"
+    view_label: "DAU"
+  }
+
+  dimension: daily_desktop_active_users {
+    type: number
+    sql: ${TABLE}."DAILY_DESKTOP_ACTIVE_USERS" ;;
+    label: "Desktop/Client DAU"
+    description: "DAU reported by Rudderstack telemetry."
+    view_label: "DAU"
+  }
+
+  measure: total_daily_desktop_active_users {
+    type: sum
+    sql: ${daily_desktop_active_users} ;;
+    label: "Total Desktop/Client DAU"
+    view_label: "DAU"
+  }
+
+  dimension: daily_legacy_active_users {
+    type: number
+    sql: ${TABLE}."DAILY_LEGACY_ACTIVE_USERS" ;;
+    label: "Legacy Desktop/Client DAU"
+    description: "DAU reported by Segment telemetry."
+    view_label: "DAU"
+  }
+
+  measure: total_daily_legacy_active_users {
+    type: sum
+    sql: ${daily_legacy_active_users} ;;
+    label: "Total Legacy Desktop/Client DAU"
+    view_label: "DAU"
+  }
+
+  dimension: daily_mobile_active_users {
+    type: number
+    sql: ${TABLE}."DAILY_MOBILE_ACTIVE_USERS" ;;
+    label: "Mobile DAU"
+    description: "DAU reported from Mobile source of Rudderstack"
+    view_label: "DAU"
+  }
+
+  measure: total_daily_mobile_active_users {
+    type: sum
+    sql: ${daily_mobile_active_users} ;;
+    label: "Total Mobile DAU"
+    view_label: "DAU"
+  }
+
+  ###
+  ### MAU
+  ###
+
+  dimension: monthly_active_users {
+    type: number
+    sql: ${TABLE}."MONTHLY_ACTIVE_USERS" ;;
+    label: "MAU"
+    description: "Number of unique users for the past 30 days"
+    view_label: "MAU"
+  }
+
+  measure: total_monthly_active_users {
+    type: sum
+    sql: ${monthly_active_users} ;;
+    label: "Total MAU"
+    view_label: "MAU"
+  }
+
+  dimension: monthly_desktop_active_users {
+    type: number
+    sql: ${TABLE}."MONTHLY_DESKTOP_ACTIVE_USERS" ;;
+    label: "Desktop/Client MAU"
+    description: "MAU reported from Rudderstack"
+    view_label: "MAU"
+  }
+
+  measure: total_monthly_desktop_active_users {
+    type: sum
+    sql: ${monthly_desktop_active_users} ;;
+    label: "Total Desktop/Client MAU"
+    view_label: "MAU"
+  }
+
+  dimension: monthly_legacy_active_users {
+    type: number
+    sql: ${TABLE}."MONTHLY_LEGACY_ACTIVE_USERS" ;;
+    label: "Legacy Desktop/Client MAU"
+    description: "MAU reported from Segment"
+    view_label: "MAU"
+  }
+
+  measure: total_monthly_legacy_active_users {
+    type: sum
+    sql: ${monthly_legacy_active_users} ;;
+    label: "Total Legacy Desktop/Client MAU"
+    view_label: "MAU"
+  }
+
+  dimension: monthly_mobile_active_users {
+    type: number
+    sql: ${TABLE}."MONTHLY_MOBILE_ACTIVE_USERS" ;;
+    label: "Mobile MAU"
+    description: "MAU reported from Mobile source of Rudderstack"
+    view_label: "MAU"
+  }
+
+  measure: total_monthly_mobile_active_users {
+    type: sum
+    sql: ${monthly_mobile_active_users} ;;
+    label: "Total Mobile MAU"
+    view_label: "MAU"
+  }
+
+  ###
+  ### WAU
+  ###
+
+  dimension: weekly_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_ACTIVE_USERS" ;;
+    label: "WAU"
+    description: "Number of unique user ids reported for the past 7 days"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_active_users {
+    type: sum
+    sql: ${weekly_active_users} ;;
+    label: "Total WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_desktop_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_DESKTOP_ACTIVE_USERS" ;;
+    label: "Desktop/Client WAU"
+    description: "WAU reported from Rudderstack"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_desktop_active_users {
+    type: sum
+    sql: ${weekly_desktop_active_users} ;;
+    label: "Total Desktop/Client WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_legacy_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_LEGACY_ACTIVE_USERS" ;;
+    label: "Legacy Desktop/Client WAU"
+    description: "WAU reported from Segment"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_legacy_active_users {
+    type: sum
+    sql: ${weekly_legacy_active_users} ;;
+    label: "Total Legacy Desktop/Client WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_mobile_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_MOBILE_ACTIVE_USERS" ;;
+    label: "Mobile WAU"
+    description: "WAU reported from Mobile source of Rudderstack"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_mobile_active_users {
+    type: sum
+    sql: ${weekly_mobile_active_users} ;;
+    label: "Total Mobile WAU"
+    view_label: "WAU"
+  }
+
+}

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -1,6 +1,6 @@
 view: fct_active_users {
 
-  sql_table_name: "MART_PRODUCT"."FCT_ACTIVE_USERS" ;;
+  sql_table_name: "mart_product"."fct_active_users" ;;
   label: "Telemetry Active Users"
 
 
@@ -10,14 +10,14 @@ view: fct_active_users {
 
   dimension: daily_server_id {
     type: string
-    sql: ${TABLE}."DAILY_SERVER_ID" ;;
+    sql: ${TABLE}."daily_server_id" ;;
     primary_key: yes
     hidden: yes
   }
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."SERVER_ID" ;;
+    sql: ${TABLE}."server_id" ;;
     label: "Server ID"
     description: "The server's ID"
   }
@@ -27,7 +27,7 @@ view: fct_active_users {
     timeframes: [raw, date, week, month, quarter, year]
     convert_tz: no
     datatype: date
-    sql: ${TABLE}."ACTIVITY_DATE" ;;
+    sql: ${TABLE}."activity_date" ;;
     label: "Server Telemetry Activity" # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
   }
@@ -38,7 +38,7 @@ view: fct_active_users {
 
   dimension: daily_active_users {
     type: number
-    sql: ${TABLE}."DAILY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."daily_active_users" ;;
     label: "DAU"
     description: "Number of unique users for current date"
     view_label: "1. DAU"
@@ -53,7 +53,7 @@ view: fct_active_users {
 
   dimension: daily_desktop_active_users {
     type: number
-    sql: ${TABLE}."DAILY_DESKTOP_ACTIVE_USERS" ;;
+    sql: ${TABLE}."daily_desktop_active_users" ;;
     label: "Desktop/Client DAU"
     description: "DAU reported by Rudderstack telemetry."
     view_label: "1. DAU"
@@ -68,7 +68,7 @@ view: fct_active_users {
 
   dimension: daily_legacy_active_users {
     type: number
-    sql: ${TABLE}."DAILY_LEGACY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."daily_legacy_active_users" ;;
     label: "Legacy Desktop/Client DAU"
     description: "DAU reported by Segment telemetry."
     view_label: "1. DAU"
@@ -83,7 +83,7 @@ view: fct_active_users {
 
   dimension: daily_mobile_active_users {
     type: number
-    sql: ${TABLE}."DAILY_MOBILE_ACTIVE_USERS" ;;
+    sql: ${TABLE}."daily_mobile_active_users" ;;
     label: "Mobile DAU"
     description: "DAU reported from Mobile source of Rudderstack"
     view_label: "1. DAU"
@@ -103,7 +103,7 @@ view: fct_active_users {
 
   dimension: weekly_active_users {
     type: number
-    sql: ${TABLE}."WEEKLY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."weekly_active_users" ;;
     label: "WAU"
     description: "Number of unique user ids reported for the past 7 days"
     view_label: "2. WAU"
@@ -118,7 +118,7 @@ view: fct_active_users {
 
   dimension: weekly_desktop_active_users {
     type: number
-    sql: ${TABLE}."WEEKLY_DESKTOP_ACTIVE_USERS" ;;
+    sql: ${TABLE}."weekly_desktop_active_users" ;;
     label: "Desktop/Client WAU"
     description: "WAU reported from Rudderstack"
     view_label: "2. WAU"
@@ -133,7 +133,7 @@ view: fct_active_users {
 
   dimension: weekly_legacy_active_users {
     type: number
-    sql: ${TABLE}."WEEKLY_LEGACY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."weekly_legacy_active_users" ;;
     label: "Legacy Desktop/Client WAU"
     description: "WAU reported from Segment"
     view_label: "2. WAU"
@@ -148,7 +148,7 @@ view: fct_active_users {
 
   dimension: weekly_mobile_active_users {
     type: number
-    sql: ${TABLE}."WEEKLY_MOBILE_ACTIVE_USERS" ;;
+    sql: ${TABLE}."weekly_mobile_active_users" ;;
     label: "Mobile WAU"
     description: "WAU reported from Mobile source of Rudderstack"
     view_label: "2. WAU"
@@ -167,7 +167,7 @@ view: fct_active_users {
 
   dimension: monthly_active_users {
     type: number
-    sql: ${TABLE}."MONTHLY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."monthly_active_users" ;;
     label: "MAU"
     description: "Number of unique users for the past 30 days"
     view_label: "3. MAU"
@@ -182,7 +182,7 @@ view: fct_active_users {
 
   dimension: monthly_desktop_active_users {
     type: number
-    sql: ${TABLE}."MONTHLY_DESKTOP_ACTIVE_USERS" ;;
+    sql: ${TABLE}."monthly_desktop_active_users" ;;
     label: "Desktop/Client MAU"
     description: "MAU reported from Rudderstack"
     view_label: "3. MAU"
@@ -197,7 +197,7 @@ view: fct_active_users {
 
   dimension: monthly_legacy_active_users {
     type: number
-    sql: ${TABLE}."MONTHLY_LEGACY_ACTIVE_USERS" ;;
+    sql: ${TABLE}."monthly_legacy_active_users" ;;
     label: "Legacy Desktop/Client MAU"
     description: "MAU reported from Segment"
     view_label: "3. MAU"
@@ -212,7 +212,7 @@ view: fct_active_users {
 
   dimension: monthly_mobile_active_users {
     type: number
-    sql: ${TABLE}."MONTHLY_MOBILE_ACTIVE_USERS" ;;
+    sql: ${TABLE}."monthly_mobile_active_users" ;;
     label: "Mobile MAU"
     description: "MAU reported from Mobile source of Rudderstack"
     view_label: "3. MAU"

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -3,6 +3,7 @@ view: fct_active_users {
   sql_table_name: "MART_PRODUCT"."FCT_ACTIVE_USERS" ;;
   label: "Telemetry Active Users"
 
+
   ###
   ### IDs and dates
   ###
@@ -86,6 +87,7 @@ view: fct_active_users {
     label: "Mobile DAU"
     description: "DAU reported from Mobile source of Rudderstack"
     view_label: "DAU"
+
   }
 
   measure: total_daily_mobile_active_users {
@@ -93,6 +95,71 @@ view: fct_active_users {
     sql: ${daily_mobile_active_users} ;;
     label: "Total Mobile DAU"
     view_label: "DAU"
+  }
+
+
+  ###
+  ### WAU
+  ###
+
+  dimension: weekly_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_ACTIVE_USERS" ;;
+    label: "WAU"
+    description: "Number of unique user ids reported for the past 7 days"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_active_users {
+    type: sum
+    sql: ${weekly_active_users} ;;
+    label: "Total WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_desktop_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_DESKTOP_ACTIVE_USERS" ;;
+    label: "Desktop/Client WAU"
+    description: "WAU reported from Rudderstack"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_desktop_active_users {
+    type: sum
+    sql: ${weekly_desktop_active_users} ;;
+    label: "Total Desktop/Client WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_legacy_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_LEGACY_ACTIVE_USERS" ;;
+    label: "Legacy Desktop/Client WAU"
+    description: "WAU reported from Segment"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_legacy_active_users {
+    type: sum
+    sql: ${weekly_legacy_active_users} ;;
+    label: "Total Legacy Desktop/Client WAU"
+    view_label: "WAU"
+  }
+
+  dimension: weekly_mobile_active_users {
+    type: number
+    sql: ${TABLE}."WEEKLY_MOBILE_ACTIVE_USERS" ;;
+    label: "Mobile WAU"
+    description: "WAU reported from Mobile source of Rudderstack"
+    view_label: "WAU"
+  }
+
+  measure: total_weekly_mobile_active_users {
+    type: sum
+    sql: ${weekly_mobile_active_users} ;;
+    label: "Total Mobile WAU"
+    view_label: "WAU"
   }
 
   ###
@@ -157,70 +224,6 @@ view: fct_active_users {
     sql: ${monthly_mobile_active_users} ;;
     label: "Total Mobile MAU"
     view_label: "MAU"
-  }
-
-  ###
-  ### WAU
-  ###
-
-  dimension: weekly_active_users {
-    type: number
-    sql: ${TABLE}."WEEKLY_ACTIVE_USERS" ;;
-    label: "WAU"
-    description: "Number of unique user ids reported for the past 7 days"
-    view_label: "WAU"
-  }
-
-  measure: total_weekly_active_users {
-    type: sum
-    sql: ${weekly_active_users} ;;
-    label: "Total WAU"
-    view_label: "WAU"
-  }
-
-  dimension: weekly_desktop_active_users {
-    type: number
-    sql: ${TABLE}."WEEKLY_DESKTOP_ACTIVE_USERS" ;;
-    label: "Desktop/Client WAU"
-    description: "WAU reported from Rudderstack"
-    view_label: "WAU"
-  }
-
-  measure: total_weekly_desktop_active_users {
-    type: sum
-    sql: ${weekly_desktop_active_users} ;;
-    label: "Total Desktop/Client WAU"
-    view_label: "WAU"
-  }
-
-  dimension: weekly_legacy_active_users {
-    type: number
-    sql: ${TABLE}."WEEKLY_LEGACY_ACTIVE_USERS" ;;
-    label: "Legacy Desktop/Client WAU"
-    description: "WAU reported from Segment"
-    view_label: "WAU"
-  }
-
-  measure: total_weekly_legacy_active_users {
-    type: sum
-    sql: ${weekly_legacy_active_users} ;;
-    label: "Total Legacy Desktop/Client WAU"
-    view_label: "WAU"
-  }
-
-  dimension: weekly_mobile_active_users {
-    type: number
-    sql: ${TABLE}."WEEKLY_MOBILE_ACTIVE_USERS" ;;
-    label: "Mobile WAU"
-    description: "WAU reported from Mobile source of Rudderstack"
-    view_label: "WAU"
-  }
-
-  measure: total_weekly_mobile_active_users {
-    type: sum
-    sql: ${weekly_mobile_active_users} ;;
-    label: "Total Mobile WAU"
-    view_label: "WAU"
   }
 
 }

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -28,7 +28,7 @@ view: fct_active_users {
     convert_tz: no
     datatype: date
     sql: ${TABLE}."ACTIVITY_DATE" ;;
-    label: "Server Telemetry Activity date"
+    label: "Server Telemetry Activity" # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
   }
 
@@ -41,14 +41,14 @@ view: fct_active_users {
     sql: ${TABLE}."DAILY_ACTIVE_USERS" ;;
     label: "DAU"
     description: "Number of unique users for current date"
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   measure: total_daily_active_users {
     type: sum
     sql: ${daily_active_users} ;;
     label: "Total DAU"
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   dimension: daily_desktop_active_users {
@@ -56,14 +56,14 @@ view: fct_active_users {
     sql: ${TABLE}."DAILY_DESKTOP_ACTIVE_USERS" ;;
     label: "Desktop/Client DAU"
     description: "DAU reported by Rudderstack telemetry."
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   measure: total_daily_desktop_active_users {
     type: sum
     sql: ${daily_desktop_active_users} ;;
     label: "Total Desktop/Client DAU"
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   dimension: daily_legacy_active_users {
@@ -71,14 +71,14 @@ view: fct_active_users {
     sql: ${TABLE}."DAILY_LEGACY_ACTIVE_USERS" ;;
     label: "Legacy Desktop/Client DAU"
     description: "DAU reported by Segment telemetry."
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   measure: total_daily_legacy_active_users {
     type: sum
     sql: ${daily_legacy_active_users} ;;
     label: "Total Legacy Desktop/Client DAU"
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
   dimension: daily_mobile_active_users {
@@ -86,15 +86,14 @@ view: fct_active_users {
     sql: ${TABLE}."DAILY_MOBILE_ACTIVE_USERS" ;;
     label: "Mobile DAU"
     description: "DAU reported from Mobile source of Rudderstack"
-    view_label: "DAU"
-
+    view_label: "1. DAU"
   }
 
   measure: total_daily_mobile_active_users {
     type: sum
     sql: ${daily_mobile_active_users} ;;
     label: "Total Mobile DAU"
-    view_label: "DAU"
+    view_label: "1. DAU"
   }
 
 
@@ -107,14 +106,14 @@ view: fct_active_users {
     sql: ${TABLE}."WEEKLY_ACTIVE_USERS" ;;
     label: "WAU"
     description: "Number of unique user ids reported for the past 7 days"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   measure: total_weekly_active_users {
     type: sum
     sql: ${weekly_active_users} ;;
     label: "Total WAU"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   dimension: weekly_desktop_active_users {
@@ -122,14 +121,14 @@ view: fct_active_users {
     sql: ${TABLE}."WEEKLY_DESKTOP_ACTIVE_USERS" ;;
     label: "Desktop/Client WAU"
     description: "WAU reported from Rudderstack"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   measure: total_weekly_desktop_active_users {
     type: sum
     sql: ${weekly_desktop_active_users} ;;
     label: "Total Desktop/Client WAU"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   dimension: weekly_legacy_active_users {
@@ -137,14 +136,14 @@ view: fct_active_users {
     sql: ${TABLE}."WEEKLY_LEGACY_ACTIVE_USERS" ;;
     label: "Legacy Desktop/Client WAU"
     description: "WAU reported from Segment"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   measure: total_weekly_legacy_active_users {
     type: sum
     sql: ${weekly_legacy_active_users} ;;
     label: "Total Legacy Desktop/Client WAU"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   dimension: weekly_mobile_active_users {
@@ -152,14 +151,14 @@ view: fct_active_users {
     sql: ${TABLE}."WEEKLY_MOBILE_ACTIVE_USERS" ;;
     label: "Mobile WAU"
     description: "WAU reported from Mobile source of Rudderstack"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   measure: total_weekly_mobile_active_users {
     type: sum
     sql: ${weekly_mobile_active_users} ;;
     label: "Total Mobile WAU"
-    view_label: "WAU"
+    view_label: "2. WAU"
   }
 
   ###
@@ -171,14 +170,14 @@ view: fct_active_users {
     sql: ${TABLE}."MONTHLY_ACTIVE_USERS" ;;
     label: "MAU"
     description: "Number of unique users for the past 30 days"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   measure: total_monthly_active_users {
     type: sum
     sql: ${monthly_active_users} ;;
     label: "Total MAU"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   dimension: monthly_desktop_active_users {
@@ -186,14 +185,14 @@ view: fct_active_users {
     sql: ${TABLE}."MONTHLY_DESKTOP_ACTIVE_USERS" ;;
     label: "Desktop/Client MAU"
     description: "MAU reported from Rudderstack"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   measure: total_monthly_desktop_active_users {
     type: sum
     sql: ${monthly_desktop_active_users} ;;
     label: "Total Desktop/Client MAU"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   dimension: monthly_legacy_active_users {
@@ -201,14 +200,14 @@ view: fct_active_users {
     sql: ${TABLE}."MONTHLY_LEGACY_ACTIVE_USERS" ;;
     label: "Legacy Desktop/Client MAU"
     description: "MAU reported from Segment"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   measure: total_monthly_legacy_active_users {
     type: sum
     sql: ${monthly_legacy_active_users} ;;
     label: "Total Legacy Desktop/Client MAU"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   dimension: monthly_mobile_active_users {
@@ -216,14 +215,14 @@ view: fct_active_users {
     sql: ${TABLE}."MONTHLY_MOBILE_ACTIVE_USERS" ;;
     label: "Mobile MAU"
     description: "MAU reported from Mobile source of Rudderstack"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
   measure: total_monthly_mobile_active_users {
     type: sum
     sql: ${monthly_mobile_active_users} ;;
     label: "Total Mobile MAU"
-    view_label: "MAU"
+    view_label: "3. MAU"
   }
 
 }

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -1,6 +1,6 @@
 view: fct_active_users {
 
-  sql_table_name: "mart_product"."fct_active_users" ;;
+  sql_table_name: "MART_PRODUCT"."fct_active_users" ;;
   label: "Telemetry Active Users"
 
 

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -1,6 +1,6 @@
 view: fct_active_users {
 
-  sql_table_name: "MART_PRODUCT"."fct_active_users" ;;
+  sql_table_name: "MART_PRODUCT"."FCT_ACTIVE_USERS" ;;
   label: "Telemetry Active Users"
 
 

--- a/views/marts/product/fct_active_users.view.lkml
+++ b/views/marts/product/fct_active_users.view.lkml
@@ -10,14 +10,14 @@ view: fct_active_users {
 
   dimension: daily_server_id {
     type: string
-    sql: ${TABLE}."daily_server_id" ;;
+    sql: ${TABLE}.daily_server_id ;;
     primary_key: yes
     hidden: yes
   }
 
   dimension: server_id {
     type: string
-    sql: ${TABLE}."server_id" ;;
+    sql: ${TABLE}.server_id ;;
     label: "Server ID"
     description: "The server's ID"
   }
@@ -27,7 +27,7 @@ view: fct_active_users {
     timeframes: [raw, date, week, month, quarter, year]
     convert_tz: no
     datatype: date
-    sql: ${TABLE}."activity_date" ;;
+    sql: ${TABLE}.activity_date ;;
     label: "Server Telemetry Activity" # Remember that `Date` is automatically appended by looker
     description: "The date current data were captured at"
   }
@@ -38,7 +38,7 @@ view: fct_active_users {
 
   dimension: daily_active_users {
     type: number
-    sql: ${TABLE}."daily_active_users" ;;
+    sql: ${TABLE}.daily_active_users ;;
     label: "DAU"
     description: "Number of unique users for current date"
     view_label: "1. DAU"
@@ -53,7 +53,7 @@ view: fct_active_users {
 
   dimension: daily_desktop_active_users {
     type: number
-    sql: ${TABLE}."daily_desktop_active_users" ;;
+    sql: ${TABLE}.daily_desktop_active_users ;;
     label: "Desktop/Client DAU"
     description: "DAU reported by Rudderstack telemetry."
     view_label: "1. DAU"
@@ -68,7 +68,7 @@ view: fct_active_users {
 
   dimension: daily_legacy_active_users {
     type: number
-    sql: ${TABLE}."daily_legacy_active_users" ;;
+    sql: ${TABLE}.daily_legacy_active_users ;;
     label: "Legacy Desktop/Client DAU"
     description: "DAU reported by Segment telemetry."
     view_label: "1. DAU"
@@ -83,7 +83,7 @@ view: fct_active_users {
 
   dimension: daily_mobile_active_users {
     type: number
-    sql: ${TABLE}."daily_mobile_active_users" ;;
+    sql: ${TABLE}.daily_mobile_active_users ;;
     label: "Mobile DAU"
     description: "DAU reported from Mobile source of Rudderstack"
     view_label: "1. DAU"
@@ -103,7 +103,7 @@ view: fct_active_users {
 
   dimension: weekly_active_users {
     type: number
-    sql: ${TABLE}."weekly_active_users" ;;
+    sql: ${TABLE}.weekly_active_users ;;
     label: "WAU"
     description: "Number of unique user ids reported for the past 7 days"
     view_label: "2. WAU"
@@ -118,7 +118,7 @@ view: fct_active_users {
 
   dimension: weekly_desktop_active_users {
     type: number
-    sql: ${TABLE}."weekly_desktop_active_users" ;;
+    sql: ${TABLE}.weekly_desktop_active_users ;;
     label: "Desktop/Client WAU"
     description: "WAU reported from Rudderstack"
     view_label: "2. WAU"
@@ -133,7 +133,7 @@ view: fct_active_users {
 
   dimension: weekly_legacy_active_users {
     type: number
-    sql: ${TABLE}."weekly_legacy_active_users" ;;
+    sql: ${TABLE}.weekly_legacy_active_users ;;
     label: "Legacy Desktop/Client WAU"
     description: "WAU reported from Segment"
     view_label: "2. WAU"
@@ -148,7 +148,7 @@ view: fct_active_users {
 
   dimension: weekly_mobile_active_users {
     type: number
-    sql: ${TABLE}."weekly_mobile_active_users" ;;
+    sql: ${TABLE}.weekly_mobile_active_users ;;
     label: "Mobile WAU"
     description: "WAU reported from Mobile source of Rudderstack"
     view_label: "2. WAU"
@@ -167,7 +167,7 @@ view: fct_active_users {
 
   dimension: monthly_active_users {
     type: number
-    sql: ${TABLE}."monthly_active_users" ;;
+    sql: ${TABLE}.monthly_active_users ;;
     label: "MAU"
     description: "Number of unique users for the past 30 days"
     view_label: "3. MAU"
@@ -182,7 +182,7 @@ view: fct_active_users {
 
   dimension: monthly_desktop_active_users {
     type: number
-    sql: ${TABLE}."monthly_desktop_active_users" ;;
+    sql: ${TABLE}.monthly_desktop_active_users ;;
     label: "Desktop/Client MAU"
     description: "MAU reported from Rudderstack"
     view_label: "3. MAU"
@@ -197,7 +197,7 @@ view: fct_active_users {
 
   dimension: monthly_legacy_active_users {
     type: number
-    sql: ${TABLE}."monthly_legacy_active_users" ;;
+    sql: ${TABLE}.monthly_legacy_active_users ;;
     label: "Legacy Desktop/Client MAU"
     description: "MAU reported from Segment"
     view_label: "3. MAU"
@@ -212,7 +212,7 @@ view: fct_active_users {
 
   dimension: monthly_mobile_active_users {
     type: number
-    sql: ${TABLE}."monthly_mobile_active_users" ;;
+    sql: ${TABLE}.monthly_mobile_active_users ;;
     label: "Mobile MAU"
     description: "MAU reported from Mobile source of Rudderstack"
     view_label: "3. MAU"


### PR DESCRIPTION
# Summary

Revised explores for DAU/MAU/WAU. The new explore allows:
- More performant query of the metrics
- Breakdown by server version and various server metadata (database, OS etc)

# Definitions

- DAU: Total number of unique user ids for the given day
- WAU: Total number of unique user ids for the given day and past 6 days (7 day rolling window)
- MAU: Total number of unique user ids for the given day and past 29 days (30 day rolling window)

# Implementation details

- The explore was added in a separate file. This is considered as a best practice.
- Drill fields have not yet specified. We can add them gradually as we discuss use cases.