### PR TITLE
MM-53463 Fix possible perf. regression introduced by True-Up review

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -3,6 +3,18 @@ include: "/**/**/*.view.lkml"
 fiscal_month_offset: -11
 week_start_day: sunday
 
+explore: license_server_fact {
+  view_label: "True Up Review"
+  group_label: "True Up Review"
+  description: "Contains all the fields for True-Up Review data"
+  fields: [view_default*]
+
+  join: user_events_telemetry {
+    sql_on: ${license_server_fact.license_id} = ${user_events_telemetry.license_id} ;;
+    relationship: many_to_one
+    fields: [true_up_review*]
+  }
+}
 
 explore: user_events_telemetry {
   label: "User Events Telemetry (Messaging)"
@@ -14,8 +26,7 @@ explore: user_events_telemetry {
     from: license_server_fact
     view_label: "License Server Fact"
     relationship: many_to_one
-    sql_on: ${user_events_telemetry.user_id} = ${license_server_fact.server_id}
-    or ${user_events_telemetry.license_id} = ${license_server_fact.license_id} ;;
+    sql_on: ${user_events_telemetry.user_id} = ${license_server_fact.server_id} ;;
   }
 
   join: license_server_fact2 {

--- a/views/blp/license_server_fact.view.lkml
+++ b/views/blp/license_server_fact.view.lkml
@@ -10,6 +10,14 @@ view: license_server_fact {
       expire_date, license_activation_date, last_active_date]
   }
 
+  set: view_default {
+    fields: [active_last_7days,last_telemetry_date, last_server_telemetry_date, id, active_paying_customer, server_id, license_id, company, edition, trial, opportunity_sfid, account_sfid, users, license_email,
+contact_sfid, account_name, stripeid, customer_id, license_customer_id, customer_name, latest_license, active_users, customer_licensed_users, monthly_active_users,
+bot_accounts, bot_posts_previous_day, direct_message_channels, incoming_webhooks, outgoing_webhooks, posts, posts_previous_day, private_channels,
+public_channels, registered_users, registered_inactive_users, slash_commands, teams, guest_accounts, issued_date,
+start_date, expire_date, license_activation_date, last_active_date, license_retired_date, ]
+  }
+
   # DIMENSIONS
   dimension: active_last_7days {
     type: yesno

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -10,6 +10,15 @@ view: user_events_telemetry {
       stripe_customer_email, category, type, user_actual_count, event_count, user_id]
   }
 
+  set: true_up_review {
+    fields: [user_events_telemetry.active_users, user_events_telemetry.event_date, user_events_telemetry.authentication_features
+      , user_events_telemetry.customer_name, user_events_telemetry.incoming_webhooks_count
+      , user_events_telemetry.license_id, user_events_telemetry.licensed_seats
+      , user_events_telemetry.outgoing_webhooks_count, user_events_telemetry.plugin_names, user_events_telemetry.server_id
+      , user_events_telemetry.server_version, user_events_telemetry.total_plugins, user_events_telemetry.server_installation_type
+      , user_events_telemetry.license_plan, user_events_telemetry.type]
+  }
+
   set: user_drill {
     fields: [user_actual_id, user_actual_role, event_count, post_count, post_reaction_count, root_count, user_id]
   }


### PR DESCRIPTION
Impact: Adds view_default set for LSF and true_up_review set for UET and also removes the `or` condition from join from UET.
Removing the `or` in join condition eliminates the LEFT OUTER JOIN in compiled SQL from LookML and reverts it back to its old state.

The view_default in license_server_fact is also required for ticket https://mattermost.atlassian.net/browse/MM-53625.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
--> 

https://mattermost.atlassian.net/browse/MM-54304

