### PR TITLE
Hotfix: Fix True Up review error which wasn't displaying fields to create Look.

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -4,15 +4,17 @@ fiscal_month_offset: -11
 week_start_day: sunday
 
 explore: license_server_fact {
-  view_label: "True Up Review"
+  label: "True Up Review"
+  view_label: "License Server Fact"
   group_label: "True Up Review"
   description: "Contains all the fields for True-Up Review data"
-  fields: [view_default*]
+  fields: [license_server_fact.lsf_true_up_review*, user_events_telemetry.uet_true_up_review*]
 
   join: user_events_telemetry {
-    sql_on: ${license_server_fact.license_id} = ${user_events_telemetry.license_id} ;;
+    from: user_events_telemetry
+    view_label: "User Events Telemetry"
     relationship: many_to_one
-    fields: [true_up_review*]
+    sql_on: ${license_server_fact.license_id} = ${user_events_telemetry.license_id} ;;
   }
 }
 

--- a/views/blp/license_server_fact.view.lkml
+++ b/views/blp/license_server_fact.view.lkml
@@ -10,12 +10,8 @@ view: license_server_fact {
       expire_date, license_activation_date, last_active_date]
   }
 
-  set: view_default {
-    fields: [active_last_7days,last_telemetry_date, last_server_telemetry_date, id, active_paying_customer, server_id, license_id, company, edition, trial, opportunity_sfid, account_sfid, users, license_email,
-contact_sfid, account_name, stripeid, customer_id, license_customer_id, customer_name, latest_license, active_users, customer_licensed_users, monthly_active_users,
-bot_accounts, bot_posts_previous_day, direct_message_channels, incoming_webhooks, outgoing_webhooks, posts, posts_previous_day, private_channels,
-public_channels, registered_users, registered_inactive_users, slash_commands, teams, guest_accounts, issued_date,
-start_date, expire_date, license_activation_date, last_active_date, license_retired_date, ]
+  set: lsf_true_up_review {
+    fields: [server_id, license_id, edition, trial, license_email, stripeid, customer_id, customer_name_unlinked]
   }
 
   # DIMENSIONS

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -10,13 +10,10 @@ view: user_events_telemetry {
       stripe_customer_email, category, type, user_actual_count, event_count, user_id]
   }
 
-  set: true_up_review {
-    fields: [user_events_telemetry.active_users, user_events_telemetry.event_date, user_events_telemetry.authentication_features
-      , user_events_telemetry.customer_name, user_events_telemetry.incoming_webhooks_count
-      , user_events_telemetry.license_id, user_events_telemetry.licensed_seats
-      , user_events_telemetry.outgoing_webhooks_count, user_events_telemetry.plugin_names, user_events_telemetry.server_id
-      , user_events_telemetry.server_version, user_events_telemetry.total_plugins, user_events_telemetry.server_installation_type
-      , user_events_telemetry.license_plan, user_events_telemetry.type]
+  set: uet_true_up_review {
+    fields: [active_users, event_date, authentication_features, user_events_telemetry.customer_name,
+      incoming_webhooks_count, license_id, licensed_seats, outgoing_webhooks_count, plugin_names, server_id, server_version,
+      total_plugins, server_installation_type, license_plan, type]
   }
 
   set: user_drill {

--- a/views/events/user_events_telemetry.view.lkml
+++ b/views/events/user_events_telemetry.view.lkml
@@ -11,7 +11,7 @@ view: user_events_telemetry {
   }
 
   set: uet_true_up_review {
-    fields: [active_users, event_date, authentication_features, user_events_telemetry.customer_name,
+    fields: [active_users, event_date, authentication_features, customer_name,
       incoming_webhooks_count, license_id, licensed_seats, outgoing_webhooks_count, plugin_names, server_id, server_version,
       total_plugins, server_installation_type, license_plan, type]
   }


### PR DESCRIPTION
Impact: Moved UET set to field parameter in explore. The fields from user_events_telemetry weren't being displayed. My assumption is that if we limit the fields in the explore (license_server_fact here) itself , it wouldn't display the fields from the views joined to the explore. We have to specify the fields which we joined from the view (in this case user_events_telemetry) to the explore in the fields parameter of the explore itself.

More info on this in this Looker documentation https://cloud.google.com/looker/docs/reference/param-explore-fields

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

