### PR TITLE
Hotfix: Reverse join on true up review explore

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -3,18 +3,18 @@ include: "/**/**/*.view.lkml"
 fiscal_month_offset: -11
 week_start_day: sunday
 
-explore: license_server_fact {
+explore: user_events_telemetry2 {
+  from: user_events_telemetry
   label: "True Up Review"
-  view_label: "License Server Fact"
+  view_label: "User Events Telemetry"
   group_label: "True Up Review"
   description: "Contains all the fields for True-Up Review data"
-  fields: [license_server_fact.lsf_true_up_review*, user_events_telemetry.uet_true_up_review*]
+  fields: [license_server_fact.lsf_true_up_review*, user_events_telemetry2.uet_true_up_review*]
 
-  join: user_events_telemetry {
-    from: user_events_telemetry
-    view_label: "User Events Telemetry"
+  join: license_server_fact {
+    view_label: "License Server Fact"
     relationship: many_to_one
-    sql_on: ${license_server_fact.license_id} = ${user_events_telemetry.license_id} ;;
+    sql_on: ${license_server_fact.license_id} = ${user_events_telemetry2.license_id} ;;
   }
 }
 


### PR DESCRIPTION
Impact: Reverse join on true up review explore so we fetch all data from user_events_telemetry.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

