### PR TITLE
MM-54964: add excludable servers, fix relation type

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -24,6 +24,13 @@ explore: fct_active_users {
     type: full_outer
     sql_on: ${fct_active_users.version_id} = ${dim_version.version_id} ;;
   }
+
+  join: dim_excludable_servers {
+    relationship: many_to_one
+    type: left_outer
+    sql_on: ${fct_active_users.server_id} = ${dim_excludable_servers.server_id} ;;
+  }
+
 }
 
 explore: fct_active_servers {
@@ -43,7 +50,7 @@ explore: fct_active_servers {
   }
 
   join: dim_excludable_servers {
-    relationship: one_to_one
+    relationship: many_to_one
     type: left_outer
     sql_on: ${fct_active_servers.server_id} = ${dim_excludable_servers.server_id} ;;
   }
@@ -67,7 +74,7 @@ explore:fct_board_activity {
   }
 
   join: dim_excludable_servers {
-    relationship: one_to_one
+    relationship: many_to_one
     type: left_outer
     sql_on: ${fct_board_activity.server_id} = ${dim_excludable_servers.server_id} ;;
   }


### PR DESCRIPTION
#### Summary

- [x] Add excludable servers relationship to daily active users model as they are not pre-excluded anymore.
- [x] Fix relationships to be many-to-one. Active users/active servers use a daily spine, so relationship to server info is many-to-one by design.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964
