### PR TITLE
MM-55026: release metrics bug fixes

### DIFF
--- a/models/data_warehouse.model.lkml
+++ b/models/data_warehouse.model.lkml
@@ -4349,24 +4349,3 @@ explore: feature_flag_telemetry {
     sql_on: ${feature_flag_telemetry.user_id} = ${excludable_servers.server_id} ;;
   }
 }
-
-explore:  fct_issues_daily_snapshot {
-  label: "JIRA Issues - Daily Snapshot"
-  group_label: "JIRA Issues"
-
-  join: dim_projects {
-    relationship: one_to_one
-    type: inner
-    sql_on: ${fct_issues_daily_snapshot.project_id} = ${dim_projects.project_id} ;;
-  }
-
-  join: dim_labels {
-    relationship: one_to_many
-    sql_on: ${fct_issues_daily_snapshot.issue_id} = ${dim_labels.issue_id} ;;
-  }
-
-  join: dim_fix_versions {
-    relationship: one_to_many
-    sql_on: ${fct_issues_daily_snapshot.issue_id} = ${dim_fix_versions.issue_id} ;;
-  }
-}

--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -25,9 +25,27 @@ explore:  fct_issues_daily_snapshot {
   }
 
 
-  join: dim_releases {
+  join: dim_release_timeframe_version {
+    from: dim_releases
     view_label: "Release Timeframe"
     relationship: many_to_one
-    sql_on: (${fct_issues_daily_snapshot.created_date} > DATEADD(month, -1, ${dim_releases.planned_release_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_releases.planned_release_date});;
+    sql_on: (${fct_issues_daily_snapshot.created_date} > DATEADD(month, -1, ${dim_release_timeframe_version.planned_release_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_release_timeframe_version.planned_release_date});;
+    fields: [dim_release_timeframe_version.version, dim_release_timeframe_version.short_version, dim_release_timeframe_version.actual_release_date, dim_release_timeframe_version.version_major, dim_release_timeframe_version.version_minor, dim_release_timeframe_version.version_patch]
+  }
+
+  join: dim_week_following_release {
+    from: dim_releases
+    view_label: "Week Following Release"
+    relationship: many_to_one
+    sql_on: (${fct_issues_daily_snapshot.created_date} <= DATEADD(day, 7, ${dim_week_following_release.actual_release_date})) and  (${fct_issues_daily_snapshot.created_date} > ${dim_week_following_release.actual_release_date});;
+    fields: [dim_week_following_release.version, dim_week_following_release.short_version, dim_week_following_release.actual_release_date, dim_week_following_release.version_major, dim_week_following_release.version_minor, dim_week_following_release.version_patch]
+  }
+
+  join: dim_rc1_cut_to_release {
+    from: dim_releases
+    view_label: "After RC1 cut"
+    relationship: many_to_one
+    sql_on: (${fct_issues_daily_snapshot.created_date} >= DATEADD(day, 7, ${dim_rc1_cut_to_release.rc1_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_rc1_cut_to_release.planned_release_date});;
+    fields: [dim_rc1_cut_to_release.version, dim_rc1_cut_to_release.short_version, dim_rc1_cut_to_release.actual_release_date, dim_rc1_cut_to_release.version_major, dim_rc1_cut_to_release.version_minor, dim_rc1_cut_to_release.version_patch]
   }
 }

--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -25,6 +25,8 @@ explore:  fct_issues_daily_snapshot {
   }
 
 
+  # Custom dimensions reusing releases to mark version that an issue falls within its release timeframe.
+  # A release timeframe is the time from previous month to the planned release date (17th-16th).
   join: dim_release_timeframe_version {
     from: dim_releases
     view_label: "Release Timeframe"
@@ -33,6 +35,7 @@ explore:  fct_issues_daily_snapshot {
     fields: [dim_release_timeframe_version.version, dim_release_timeframe_version.short_version, dim_release_timeframe_version.actual_release_date, dim_release_timeframe_version.version_major, dim_release_timeframe_version.version_minor, dim_release_timeframe_version.version_patch]
   }
 
+  # Week following release is the 7 days after the actual release date.
   join: dim_week_following_release {
     from: dim_releases
     view_label: "Week Following Release"
@@ -41,6 +44,7 @@ explore:  fct_issues_daily_snapshot {
     fields: [dim_week_following_release.version, dim_week_following_release.short_version, dim_week_following_release.actual_release_date, dim_week_following_release.version_major, dim_week_following_release.version_minor, dim_week_following_release.version_patch]
   }
 
+  # Time between RC1 cut date and planned release date.
   join: dim_rc1_cut_to_release {
     from: dim_releases
     view_label: "After RC1 cut"

--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -49,7 +49,7 @@ explore:  fct_issues_daily_snapshot {
     from: dim_releases
     view_label: "After RC1 cut"
     relationship: many_to_one
-    sql_on: (${fct_issues_daily_snapshot.created_date} >= DATEADD(day, 7, ${dim_rc1_cut_to_release.rc1_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_rc1_cut_to_release.planned_release_date});;
+    sql_on: (${fct_issues_daily_snapshot.created_date} >= ${dim_rc1_cut_to_release.rc1_date}) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_rc1_cut_to_release.planned_release_date});;
     fields: [dim_rc1_cut_to_release.version, dim_rc1_cut_to_release.short_version, dim_rc1_cut_to_release.actual_release_date, dim_rc1_cut_to_release.version_major, dim_rc1_cut_to_release.version_minor, dim_rc1_cut_to_release.version_patch]
   }
 }

--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -24,10 +24,10 @@ explore:  fct_issues_daily_snapshot {
     sql_on: ${fct_issues_daily_snapshot.issue_id} = ${dim_fix_versions.issue_id} ;;
   }
 
-  join: dim_release_timeframe {
-    from:  dim_fix_versions
+
+  join: dim_releases {
     view_label: "Release Timeframe"
     relationship: many_to_one
-    sql_on: (${fct_issues_daily_snapshot.created_date} > DATEADD(month, -1, ${dim_release_timeframe.planned_release_date_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_release_timeframe.planned_release_date_date});;
+    sql_on: (${fct_issues_daily_snapshot.created_date} > DATEADD(month, -1, ${dim_releases.planned_release_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_releases.planned_release_date});;
   }
 }

--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -1,0 +1,33 @@
+connection: "snowflake"
+
+# Limit include only to the ones really needed by this explore
+include: "/views/marts/release/*.view.lkml"
+
+
+explore:  fct_issues_daily_snapshot {
+  label: "JIRA Issues - Daily Snapshot"
+  group_label: "JIRA Issues"
+
+  join: dim_projects {
+    relationship: one_to_one
+    type: inner
+    sql_on: ${fct_issues_daily_snapshot.project_id} = ${dim_projects.project_id} ;;
+  }
+
+  join: dim_labels {
+    relationship: one_to_many
+    sql_on: ${fct_issues_daily_snapshot.issue_id} = ${dim_labels.issue_id} ;;
+  }
+
+  join: dim_fix_versions {
+    relationship: one_to_many
+    sql_on: ${fct_issues_daily_snapshot.issue_id} = ${dim_fix_versions.issue_id} ;;
+  }
+
+  join: dim_release_timeframe {
+    from:  dim_fix_versions
+    view_label: "Release Timeframe"
+    relationship: many_to_one
+    sql_on: (${fct_issues_daily_snapshot.created_date} > DATEADD(month, -1, ${dim_release_timeframe.planned_release_date_date})) and  (${fct_issues_daily_snapshot.created_date} <= ${dim_release_timeframe.planned_release_date_date});;
+  }
+}

--- a/views/marts/release/dim_fix_versions.view.lkml
+++ b/views/marts/release/dim_fix_versions.view.lkml
@@ -77,6 +77,13 @@ view: dim_fix_versions {
     sql: ${TABLE}."VERSION_MINOR" ;;
   }
 
+  dimension: version_patch {
+    label: "Patch Version"
+    description: "The patch part of the semantic version"
+    type: number
+    sql: ${TABLE}."VERSION_PATCH" ;;
+  }
+
   measure: count {
     type: count
     drill_fields: []

--- a/views/marts/release/dim_fix_versions.view.lkml
+++ b/views/marts/release/dim_fix_versions.view.lkml
@@ -26,24 +26,6 @@ view: dim_fix_versions {
     sql: ${TABLE}."CLOUD_RELEASE_DATE" ;;
   }
 
-  dimension_group: planned_release_date {
-    label: "Planned Release Date"
-    description: "The planned date of the release"
-    type: time
-    timeframes: [
-      raw,
-      date,
-      week,
-      month,
-      quarter,
-      year
-    ]
-    convert_tz: no
-    datatype: date
-    sql: ${TABLE}."PLANNED_RELEASE_DATE" ;;
-  }
-
-
   dimension: component {
     description: "The component this release refers to"
     type: string
@@ -84,8 +66,18 @@ view: dim_fix_versions {
     sql: ${TABLE}."VERSION_PATCH" ;;
   }
 
-  measure: count {
-    type: count
-    drill_fields: []
+  dimension: is_on_prem_release {
+    label: "Is On-prem Fix Version?"
+    description: "Whether this fix version is an on-prem fix version"
+    type: yesno
+    sql: ${TABLE}.is_on_prem_release ;;
   }
+
+  dimension: is_cloud_release {
+    label: "Is Cloud Fix Version?"
+    description: "Whether this fix version is a Cloud fix version"
+    type: yesno
+    sql: ${TABLE}.is_cloud_release ;;
+  }
+
 }

--- a/views/marts/release/dim_releases.view.lkml
+++ b/views/marts/release/dim_releases.view.lkml
@@ -1,0 +1,86 @@
+view: dim_releases {
+
+  sql_table_name: "MART_RELEASE".dim_releases ;;
+
+  dimension: version {
+    type: string
+    sql: ${TABLE}.version ;;
+    primary_key: yes
+    label: "Version"
+    description: "The release's version number."
+  }
+
+
+  dimension: short_version {
+    type: string
+    sql: ${TABLE}.short_version ;;
+    label: "Short version"
+    description: "Major and minor version, prefixed with 'v'"
+  }
+
+
+
+  dimension: version_major {
+    type: string
+    sql: ${TABLE}."VERSION_MAJOR" ;;
+    label: "Major Version"
+    description: "The major part of the semantic version"
+  }
+
+  dimension: version_minor {
+    type: string
+    sql: ${TABLE}."VERSION_MINOR" ;;
+    label: "Minor Version"
+    description: "The minor part of the semantic version"
+
+  }
+
+  dimension: version_patch {
+    type: string
+    sql: ${TABLE}."VERSION_PATCH" ;;
+    label: "Patch Version"
+    description: "The patch part of the semantic version"
+  }
+
+
+  dimension_group: rc1 {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.rc1_date ;;
+    label: "RC1 Cut"
+  }
+
+
+  dimension_group: planned_release {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.planned_release_date ;;
+    label: "Planned Release"
+  }
+
+  dimension_group: actual_release {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.actual_release_date ;;
+    label: "Actual Release"
+  }
+
+  dimension: is_supported {
+    type: yesno
+    sql: ${TABLE}.is_supported ;;
+    label: "Is Supported?"
+  }
+
+
+  dimension: release_number {
+    type: number
+    sql: ${TABLE}.release_number ;;
+    hidden:  yes
+  }
+}

--- a/views/marts/release/fct_issues_daily_snapshot.view.lkml
+++ b/views/marts/release/fct_issues_daily_snapshot.view.lkml
@@ -14,6 +14,11 @@ view: fct_issues_daily_snapshot {
   dimension: issue_key {
     type: string
     sql: ${TABLE}."ISSUE_KEY" ;;
+    # Add a link to JIRA to make it easier to open specific issues directly from Looker
+    link: {
+      label: "Open in JIRA"
+      url: "https://mattermost.atlassian.net/browse/{{ value }}"
+    }
   }
 
   dimension: resolution {
@@ -81,6 +86,6 @@ view: fct_issues_daily_snapshot {
 
   measure: count {
     type: count
-    drill_fields: []
+    drill_fields: [issue_key, issue_type, created_date, status]
   }
 }


### PR DESCRIPTION
#### Summary

First round of revisions for release dashboard.
- [x] Add a custom join to fix version for determining the release when release timeframe.
- [x] Move release model to separate file.
- [x] Usability improvements (drill fields on count issues, clickable links to JIRA) 
- [x] Add references to release as separate dimensions based on release timeframes (previous release to planned release, RC1 to planned release, week following release etc). 


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55026

