### PR TITLE
MM-55026: fix typo

### DIFF
--- a/models/release.model.lkml
+++ b/models/release.model.lkml
@@ -50,7 +50,7 @@ explore:  fct_issues_daily_snapshot {
     view_label: "Release Window"
     relationship: many_to_many
     # Note that this might result in issues being counted for multiple releases if releases with overlapping release dates exist.
-    sql_on: ${fct_issues_daily_snapshot.created_date} >= if(${dim_release_window.rc1_date} > ${dim_release_window.release_start_date}, ${dim_release_window.release_start_date}, ${dim_release_window.rc1_date})  and ${fct_issues_daily_snapshot.created_date} < ${dim_release_window.actual_release_date} ;;
+    sql_on: ${fct_issues_daily_snapshot.created_date} >= least(${dim_release_window.rc1_date}, ${dim_release_window.release_start_date})  and ${fct_issues_daily_snapshot.created_date} < ${dim_release_window.actual_release_date} ;;
   }
 
 }


### PR DESCRIPTION
#### Summary

Replace `if` with `least`.

Note that this is an `sql_on` definition, which expects SQL rather than Looker expressions. `if` is a valid looker logic operator, but doesn't exist in snowflake. This PR uses snowflake's [LEAST](https://docs.snowflake.com/en/sql-reference/functions/least) to get the minimum of two values.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55026