### PR TITLE
Add Cloud 360 Explore, Dims, Sales renewal dashboard

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -226,9 +226,9 @@ explore: fct_subscription_history {
     sql_on:  ${fct_subscription_history.customer_id} = ${dim_self_serve_customers.customer_id} ;;
   }
 
-  join: dim_server_info {
-    relationship: many_to_many
-    type: full_outer
-    sql_on:  ${fct_subscription_history.cws_installation} = ${dim_server_info.installation_id} ;;
+  join: dim_installation_summary {
+    relationship: many_to_one
+    type:  left_outer
+    sql_on:  ${fct_subscription_history.cws_installation} = ${dim_installation_summary.installation_id} ;;
   }
 }

--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -215,3 +215,20 @@ explore: rpt_active_user_base {
   label: "Active User Base"
   group_label: "[New] Active Users"
 }
+
+explore: fct_subscription_history {
+  label: "Cloud Subscription History (360)"
+  group_label: "[New] Cloud 360"
+
+  join: dim_self_serve_customers {
+    relationship: many_to_one
+    type:  left_outer
+    sql_on:  ${fct_subscription_history.customer_id} = ${dim_self_serve_customers.customer_id} ;;
+  }
+
+  join: dim_server_info {
+    relationship: many_to_many
+    type: full_outer
+    sql_on:  ${fct_subscription_history.cws_installation} = ${dim_server_info.installation_id} ;;
+  }
+}

--- a/views/marts/product/dim_installation_summary.view.lkml
+++ b/views/marts/product/dim_installation_summary.view.lkml
@@ -1,0 +1,92 @@
+# The name of this view in Looker is "Dim Installation Summary"
+view: dim_installation_summary {
+  # The sql_table_name parameter indicates the underlying database table
+  # to be used for all fields in this view.
+  sql_table_name: "MART_PRODUCT"."DIM_INSTALLATION_SUMMARY" ;;
+
+  # No primary key is defined for this view. In order to join this view in an Explore,
+  # define primary_key: yes on a dimension that has no repeated values.
+
+    # Here's what a typical dimension looks like in LookML.
+    # A dimension is a groupable field that can be used to filter query results.
+    # This dimension will be called "Count Server Ids" in Explore.
+
+  dimension: count_server_ids {
+    type: number
+    value_format_name: id
+    sql: ${TABLE}."COUNT_SERVER_IDS" ;;
+  }
+  # Dates and timestamps can be represented in Looker using a dimension group of type: time.
+  # Looker converts dates and timestamps to the specified timeframes within the dimension group.
+
+  dimension_group: first_activity {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}."FIRST_ACTIVITY_DATE" ;;
+  }
+
+  dimension: first_binary_edition {
+    type: string
+    sql: ${TABLE}."FIRST_BINARY_EDITION" ;;
+  }
+
+  dimension: first_count_registered_active_users {
+    type: number
+    sql: ${TABLE}."FIRST_COUNT_REGISTERED_ACTIVE_USERS" ;;
+  }
+
+  # A measure is a field that uses a SQL aggregate function. Here are defined sum and average
+  # measures for this dimension, but you can also add measures of many different aggregates.
+  # Click on the type parameter to see all the options in the Quick Help panel on the right.
+
+  measure: total_first_count_registered_active_users {
+    type: sum
+    sql: ${first_count_registered_active_users} ;;  }
+  measure: average_first_count_registered_active_users {
+    type: average
+    sql: ${first_count_registered_active_users} ;;  }
+
+  dimension: installation_id {
+    type: string
+    sql: ${TABLE}."INSTALLATION_ID" ;;
+    primary_key: yes
+  }
+
+  dimension_group: last_activity {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}."LAST_ACTIVITY_DATE" ;;
+  }
+
+  dimension: last_binary_edition {
+    type: string
+    sql: ${TABLE}."LAST_BINARY_EDITION" ;;
+  }
+
+  dimension: last_count_registered_active_users {
+    type: number
+    sql: ${TABLE}."LAST_COUNT_REGISTERED_ACTIVE_USERS" ;;
+  }
+
+  dimension: last_daily_active_users {
+    type: number
+    sql: ${TABLE}."LAST_DAILY_ACTIVE_USERS" ;;
+  }
+
+  dimension: last_monthly_active_users {
+    type: number
+    sql: ${TABLE}."LAST_MONTHLY_ACTIVE_USERS" ;;
+  }
+
+  dimension: last_server_id {
+    type: string
+    sql: ${TABLE}."LAST_SERVER_ID" ;;
+  }
+  measure: count {
+    type: count
+  }
+}

--- a/views/marts/sales/dim_self_serve_customers.view.lkml
+++ b/views/marts/sales/dim_self_serve_customers.view.lkml
@@ -22,6 +22,7 @@ view: dim_self_serve_customers {
   }
 
   dimension: customer_id {
+    primary_key:  yes
     type: string
     sql: ${TABLE}."CUSTOMER_ID" ;;
   }

--- a/views/marts/sales/dim_self_serve_customers.view.lkml
+++ b/views/marts/sales/dim_self_serve_customers.view.lkml
@@ -1,0 +1,42 @@
+# The name of this view in Looker is "Dim Self Serve Customers"
+view: dim_self_serve_customers {
+  # The sql_table_name parameter indicates the underlying database table
+  # to be used for all fields in this view.
+  sql_table_name: "MART_SALES"."DIM_SELF_SERVE_CUSTOMERS" ;;
+
+  # No primary key is defined for this view. In order to join this view in an Explore,
+  # define primary_key: yes on a dimension that has no repeated values.
+
+    # Here's what a typical dimension looks like in LookML.
+    # A dimension is a groupable field that can be used to filter query results.
+    # This dimension will be called "Contact First Name" in Explore.
+
+  dimension: contact_first_name {
+    type: string
+    sql: ${TABLE}."CONTACT_FIRST_NAME" ;;
+  }
+
+  dimension: contact_last_name {
+    type: string
+    sql: ${TABLE}."CONTACT_LAST_NAME" ;;
+  }
+
+  dimension: customer_id {
+    type: string
+    sql: ${TABLE}."CUSTOMER_ID" ;;
+  }
+
+  dimension: email {
+    type: string
+    sql: ${TABLE}."EMAIL" ;;
+  }
+
+  dimension: name {
+    type: string
+    sql: ${TABLE}."NAME" ;;
+  }
+  measure: count {
+    type: count
+    drill_fields: [name, contact_last_name, contact_first_name]
+  }
+}

--- a/views/marts/sales/fct_subscription_history.view.lkml
+++ b/views/marts/sales/fct_subscription_history.view.lkml
@@ -1,0 +1,92 @@
+# The name of this view in Looker is "Fct Subscription History"
+view: fct_subscription_history {
+  # The sql_table_name parameter indicates the underlying database table
+  # to be used for all fields in this view.
+  sql_table_name: "MART_SALES"."FCT_SUBSCRIPTION_HISTORY" ;;
+
+  # No primary key is defined for this view. In order to join this view in an Explore,
+  # define primary_key: yes on a dimension that has no repeated values.
+
+    # Here's what a typical dimension looks like in LookML.
+    # A dimension is a groupable field that can be used to filter query results.
+    # This dimension will be called "Billing Type" in Explore.
+
+  dimension: billing_type {
+    type: string
+    sql: ${TABLE}."BILLING_TYPE" ;;
+  }
+  # Dates and timestamps can be represented in Looker using a dimension group of type: time.
+  # Looker converts dates and timestamps to the specified timeframes within the dimension group.
+
+  dimension_group: created {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: ${TABLE}."CREATED_AT" ;;
+  }
+
+  dimension: customer_id {
+    type: string
+    sql: ${TABLE}."CUSTOMER_ID" ;;
+  }
+
+  dimension: cws_dns {
+    type: string
+    sql: ${TABLE}."CWS_DNS" ;;
+  }
+
+  dimension: cws_installation {
+    type: string
+    sql: ${TABLE}."CWS_INSTALLATION" ;;
+  }
+
+  dimension: is_latest {
+    type: yesno
+    sql: ${TABLE}."IS_LATEST" ;;
+  }
+
+  dimension_group: license_end {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: CAST(${TABLE}."LICENSE_END_AT" AS TIMESTAMP_NTZ) ;;
+  }
+
+  dimension_group: license_start {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: CAST(${TABLE}."LICENSE_START_AT" AS TIMESTAMP_NTZ) ;;
+  }
+
+  dimension: licensed_seats {
+    type: number
+    sql: ${TABLE}."LICENSED_SEATS" ;;
+  }
+
+  # A measure is a field that uses a SQL aggregate function. Here are defined sum and average
+  # measures for this dimension, but you can also add measures of many different aggregates.
+  # Click on the type parameter to see all the options in the Quick Help panel on the right.
+
+  measure: total_licensed_seats {
+    type: sum
+    sql: ${licensed_seats} ;;  }
+  measure: average_licensed_seats {
+    type: average
+    sql: ${licensed_seats} ;;  }
+
+  dimension: status {
+    type: string
+    sql: ${TABLE}."STATUS" ;;
+  }
+
+  dimension: subscription_history_event_id {
+    type: string
+    sql: ${TABLE}."SUBSCRIPTION_HISTORY_EVENT_ID" ;;
+  }
+
+  dimension: subscription_id {
+    type: string
+    sql: ${TABLE}."SUBSCRIPTION_ID" ;;
+  }
+  measure: count {
+    type: count
+  }
+}

--- a/views/marts/sales/fct_subscription_history.view.lkml
+++ b/views/marts/sales/fct_subscription_history.view.lkml
@@ -79,6 +79,7 @@ view: fct_subscription_history {
 
   dimension: subscription_history_event_id {
     type: string
+    primary_key:  yes
     sql: ${TABLE}."SUBSCRIPTION_HISTORY_EVENT_ID" ;;
   }
 


### PR DESCRIPTION

#### Summary
Adds explore for fct_subscription_history, as a "Cloud 360"
Adds veiw for dim_self_serve_customers
Adds a dashboard to provide sales with information on all renewals (including filters for upcoming, and views of billable user counts over time)
#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7699

