### PR TITLE
MM-59410 - Adding dim_server_info to the "Feature usage" explore

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -194,6 +194,11 @@ explore: fct_feature_daily_snapshot {
     sql_on: ${fct_feature_daily_snapshot.server_id} = ${dim_excludable_servers.server_id} ;;
   }
 
+  join: dim_server_info {  
+    relationship: many_to_one  
+    type: full_outer  
+    sql_on: ${fct_feature_daily_snapshot.server_id} = ${dim_server_info.server_id} ;;  
+  }
 
   join: dim_cloud_customers {
     relationship: many_to_one


### PR DESCRIPTION
#### Summary
Adding join to the `dim_server_info` view to the "Feature Usage" explore. The reason is to help implement MM-59410, to use the "hosting type" to be able to display either cloud or self-hosted customer info, depending on the server type. Technically, there should be no need for that right now, the cloud installs have the full set of features, but could not find any other explore that would make sense to use in the context of MM-59410. 

Other options would be to create a separate explore for MM-59410 and alike or to use smth. like `rpt_active_user_base` (which coalesces cloud and self-hosted customer metadata and is the only explore that uses the latest customer info - `dim_latest_server_customer_info`).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59410