### PR TITLE
MM-59880 - Add all exclusion reasons filter

### DIFF
--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -136,6 +136,14 @@ view: dim_excludable_servers {
     view_label: "Server: Exclusion Reasons"
   }
 
+  dimension: has_no_reason {
+    type: yesno
+    sql:  not(${has_reason_single_day_security_only} or ${has_reason_custom_build_version_format} or ${has_reason_single_day_server_side_telemetry_only} or ${has_reason_single_day_telemetry_only} or ${has_reason_ran_tests} or ${has_reason_active_users__registered_users} or ${has_reason_no_stripe_installation_found} or ${has_reason_single_day_user_telemetry_only} or ${has_reason_restricted_ip} or ${has_reason_invalid_server_id} or ${has_reason_internal_email} or ${has_reason_test_server} or ${has_reason_community});;
+    label: "No reason"
+    description: "Whether the server has reported no reason for exclusion"
+    view_label: "Server: Exclusion Reasons"
+  }
+
   dimension: company_scorecard_exclusions {
     type: yesno
     sql: ((${has_reason_active_users__registered_users} <> 'Yes' OR ${has_reason_active_users__registered_users} IS NULL) AND
@@ -149,26 +157,6 @@ view: dim_excludable_servers {
     (${has_reason_test_server} <> 'Yes' OR ${has_reason_test_server} IS NULL));;
     label: "Company Scorecard Exclusions"
     description: "A combination of exclusion reasons which applies to company scorecard data"
-    view_label: "Server: Exclusion Reasons"
-  }
-
-dimension: all_exclusions {
-    type: yesno
-    sql: ((${has_reason_active_users__registered_users} <> 'Yes' OR ${has_reason_active_users__registered_users} IS NULL) AND
-    (${has_reason_community} <> 'Yes' OR ${has_reason_community} IS NULL) AND
-    (${has_reason_invalid_server_id} <> 'Yes' OR  ${has_reason_invalid_server_id} IS NULL) AND
-    (${has_reason_internal_email} <> 'Yes' OR ${has_reason_internal_email} IS NULL) AND
-    (${has_reason_custom_build_version_format} <> 'Yes' OR ${has_reason_custom_build_version_format} IS NULL) AND
-    (${has_reason_no_stripe_installation_found} <> 'Yes' OR ${has_reason_no_stripe_installation_found} IS NULL) AND
-    (${has_reason_ran_tests} <> 'Yes' OR ${has_reason_ran_tests} IS NULL) AND
-    (${has_reason_restricted_ip} <> 'Yes' OR ${has_reason_restricted_ip} IS NULL) AND
-    (${has_reason_test_server} <> 'Yes' OR ${has_reason_test_server} IS NULL);;
-    (${has_reason_single_day_security_only} <> 'Yes' OR ${has_reason_single_day_security_only} IS NULL);;
-    (${has_reason_single_day_server_side_telemetry_only} <> 'Yes' OR ${has_reason_single_day_server_side_telemetry_only} IS NULL);;
-    (${has_reason_single_day_user_telemetry_only} <> 'Yes' OR ${has_reason_single_day_user_telemetry_only} IS NULL);;
-    (${has_reason_single_day_telemetry_only} <> 'Yes' OR ${has_reason_single_day_telemetry_only} IS NULL));;
-    label: "All Exclusions"
-    description: "All available exclusion reasons"
     view_label: "Server: Exclusion Reasons"
   }
 }

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -138,7 +138,7 @@ view: dim_excludable_servers {
 
   dimension: has_any_reason_wrapper {
     type: yesno
-    sql:  sql: CASE WHEN ${has_any_reason} IS NOT NULL THEN FALSE ELSE TRUE END ;;
+    sql:  CASE WHEN ${has_any_reason} IS NOT NULL THEN FALSE ELSE TRUE END ;;
     label: "Any reason wrapper"
     description: "If the server has reported any reason for exclusion, exclude, otherwise return everything"
     view_label: "Server: Exclusion Reasons"

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -138,7 +138,7 @@ view: dim_excludable_servers {
 
   dimension: has_no_reason {
     type: yesno
-    sql:  has_any_reason is null ;;
+    sql:  ${has_no_reason} is null ;;
     label: "No reason"
     description: "Whether the server has reported no reason for exclusion"
     view_label: "Server: Exclusion Reasons"

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -138,7 +138,7 @@ view: dim_excludable_servers {
 
   dimension: has_no_reason {
     type: yesno
-    sql:  not(${has_reason_single_day_security_only} or ${has_reason_custom_build_version_format} or ${has_reason_single_day_server_side_telemetry_only} or ${has_reason_single_day_telemetry_only} or ${has_reason_ran_tests} or ${has_reason_active_users__registered_users} or ${has_reason_no_stripe_installation_found} or ${has_reason_single_day_user_telemetry_only} or ${has_reason_restricted_ip} or ${has_reason_invalid_server_id} or ${has_reason_internal_email} or ${has_reason_test_server} or ${has_reason_community});;
+    sql:  has_any_reason is null ;;
     label: "No reason"
     description: "Whether the server has reported no reason for exclusion"
     view_label: "Server: Exclusion Reasons"

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -136,11 +136,11 @@ view: dim_excludable_servers {
     view_label: "Server: Exclusion Reasons"
   }
 
-  dimension: has_no_reason {
+  dimension: has_any_reason_wrapper {
     type: yesno
-    sql:  ${has_any_reason} is null ;;
-    label: "No reason"
-    description: "Whether the server has reported no reason for exclusion"
+    sql:  sql: CASE WHEN ${has_any_reason} IS NOT NULL THEN FALSE ELSE TRUE END ;;
+    label: "Any reason wrapper"
+    description: "If the server has reported any reason for exclusion, exclude, otherwise return everything"
     view_label: "Server: Exclusion Reasons"
   }
 

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -138,7 +138,7 @@ view: dim_excludable_servers {
 
   dimension: has_any_reason_wrapper {
     type: yesno
-    sql:  CASE WHEN ${has_any_reason} IS NOT NULL THEN FALSE ELSE TRUE END ;;
+    sql:  CASE WHEN ${has_any_reason} THEN FALSE ELSE TRUE END ;;
     label: "Any reason wrapper"
     description: "If the server has reported any reason for exclusion, exclude, otherwise return everything"
     view_label: "Server: Exclusion Reasons"

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -152,4 +152,23 @@ view: dim_excludable_servers {
     view_label: "Server: Exclusion Reasons"
   }
 
+dimension: all_exclusions {
+    type: yesno
+    sql: ((${has_reason_active_users__registered_users} <> 'Yes' OR ${has_reason_active_users__registered_users} IS NULL) AND
+    (${has_reason_community} <> 'Yes' OR ${has_reason_community} IS NULL) AND
+    (${has_reason_invalid_server_id} <> 'Yes' OR  ${has_reason_invalid_server_id} IS NULL) AND
+    (${has_reason_internal_email} <> 'Yes' OR ${has_reason_internal_email} IS NULL) AND
+    (${has_reason_custom_build_version_format} <> 'Yes' OR ${has_reason_custom_build_version_format} IS NULL) AND
+    (${has_reason_no_stripe_installation_found} <> 'Yes' OR ${has_reason_no_stripe_installation_found} IS NULL) AND
+    (${has_reason_ran_tests} <> 'Yes' OR ${has_reason_ran_tests} IS NULL) AND
+    (${has_reason_restricted_ip} <> 'Yes' OR ${has_reason_restricted_ip} IS NULL) AND
+    (${has_reason_test_server} <> 'Yes' OR ${has_reason_test_server} IS NULL);;
+    (${has_reason_single_day_security_only} <> 'Yes' OR ${has_reason_single_day_security_only} IS NULL);;
+    (${has_reason_single_day_server_side_telemetry_only} <> 'Yes' OR ${has_reason_single_day_server_side_telemetry_only} IS NULL);;
+    (${has_reason_single_day_user_telemetry_only} <> 'Yes' OR ${has_reason_single_day_user_telemetry_only} IS NULL);;
+    (${has_reason_single_day_telemetry_only} <> 'Yes' OR ${has_reason_single_day_telemetry_only} IS NULL));;
+    label: "All Exclusions"
+    description: "All available exclusion reasons"
+    view_label: "Server: Exclusion Reasons"
+  }
 }

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -136,11 +136,11 @@ view: dim_excludable_servers {
     view_label: "Server: Exclusion Reasons"
   }
 
-  dimension: has_any_reason_wrapper {
+  dimension: has_no_reason {
     type: yesno
-    sql:  CASE WHEN ${has_any_reason} THEN FALSE ELSE TRUE END ;;
-    label: "Any reason wrapper"
-    description: "If the server has reported any reason for exclusion, exclude, otherwise return everything"
+    sql:  ${has_any_reason} is null ;;
+    label: "No reason"
+    description: "Whether the server has reported no reason for exclusion"
     view_label: "Server: Exclusion Reasons"
   }
 

--- a/views/marts/product/dim_excludable_servers.view.lkml
+++ b/views/marts/product/dim_excludable_servers.view.lkml
@@ -138,7 +138,7 @@ view: dim_excludable_servers {
 
   dimension: has_no_reason {
     type: yesno
-    sql:  ${has_no_reason} is null ;;
+    sql:  ${has_any_reason} is null ;;
     label: "No reason"
     description: "Whether the server has reported no reason for exclusion"
     view_label: "Server: Exclusion Reasons"


### PR DESCRIPTION
#### Summary
Add a `has_no reason` dimension to `dim_excludable_servers` view - need this in order to have "Yes" as the default option for the Looker dashboard filter (versus using the `has_any_reason` dimension). Reason is because the `has_any_reason` filter - if "true" - returns the entries that have at least one exclusion reason. However, what we need is to filter these out - hence we need the "false" value - which would map to No, so instead we're flipping the logic and build the filter off the "Yes" of `has_no reason`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59880
