### PR TITLE
MM-59958 - Enhance fct_active_servers view with dim_daily_server_info data

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -96,9 +96,9 @@ explore: fct_active_servers {
   join: dim_daily_server_info {
     relationship: one_to_one
     type: left_outer # Telemetry might not have been submitted from server at a given time
-    sql_on: ${fct_active_users.daily_server_id} = ${dim_daily_server_info.daily_server_id} ;;
+    sql_on: ${fct_active_servers.daily_server_id} = ${dim_daily_server_info.daily_server_id} ;;
   }
-  
+
   join: dim_version {
     relationship:  many_to_one
     type: full_outer

--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -93,6 +93,12 @@ explore: fct_active_servers {
   label: "Telemetry Active Servers"
   group_label: "[New] Active Servers"
 
+  join: dim_daily_server_info {
+    relationship: one_to_one
+    type: left_outer # Telemetry might not have been submitted from server at a given time
+    sql_on: ${fct_active_users.daily_server_id} = ${dim_daily_server_info.daily_server_id} ;;
+  }
+  
   join: dim_version {
     relationship:  many_to_one
     type: full_outer

--- a/views/marts/product/fct_active_servers.view.lkml
+++ b/views/marts/product/fct_active_servers.view.lkml
@@ -127,4 +127,23 @@ view: fct_active_servers {
     view_label: " * Metrics: Active Servers"
     drill_fields: [server_id]
   }
+
+  # filters
+  dimension: last_day_of_month {
+    type: yesno
+    description: "Filters so the logging date is equal to the last day of the month."
+    sql: CASE WHEN ${activity_date} =
+                                      CASE WHEN DATE_TRUNC('month', ${activity_date}::date) = DATE_TRUNC('month', CURRENT_DATE) THEN (SELECT MAX(activity_date) FROM "MART_PRODUCT"."FCT_ACTIVE_SERVERS")
+                                        ELSE DATEADD(MONTH, 1, DATE_TRUNC('month',${activity_date}::date)) - INTERVAL '1 DAY' END
+          THEN TRUE ELSE FALSE END ;;
+  }
+
+  dimension: last_day_of_week {
+    type: yesno
+    description: "Filters so the logging date is equal to the last day of the week."
+    sql: CASE WHEN ${activity_date} =
+                                      CASE WHEN DATE_TRUNC('week', ${activity_date}::date) = DATE_TRUNC('week', CURRENT_DATE) THEN (SELECT MAX(activity_date) FROM "MART_PRODUCT"."FCT_ACTIVE_SERVERS")
+                                        ELSE DATEADD(WEEK, 1, DATE_TRUNC('week',${activity_date}::date)) - INTERVAL '1 DAY' END
+          THEN TRUE ELSE FALSE END ;;
+  }
 }


### PR DESCRIPTION
#### Summary

- [x] Join with dim_daily_server_info in the fct_active_servers view - mainly to surface age(days) in some new Looker dashboards.
- [x] Add last_week and last_month day filters

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59958
