### PR TITLE
Hotfix: convert logentries version parts to numbers

### DIFF
--- a/views/marts/product/fct_downloads.view.lkml
+++ b/views/marts/product/fct_downloads.view.lkml
@@ -169,21 +169,21 @@ view: fct_downloads {
   }
 
   dimension: version_major {
-    type: string
+    type: number
     sql: ${TABLE}.version_major ;;
     label: "Major"
     group_label: "Version"
   }
 
   dimension: version_minor {
-    type: string
+    type: number
     sql: ${TABLE}.version_minor ;;
     label: "Minor"
     group_label: "Version"
   }
 
   dimension: version_patch {
-    type: string
+    type: number
     sql: ${TABLE}.version_patch ;;
     label: "Patch"
     group_label: "Version"


### PR DESCRIPTION
#### Summary

Use proper type from version parts of downloads. Follow up of https://github.com/mattermost/mattermost-data-warehouse/pull/1578.