### PR TITLE
Chore: Move Looker TRANSFORM_L workload to TRANSFORM_XS

### DIFF
--- a/models/data_warehouse_l.model.lkml
+++ b/models/data_warehouse_l.model.lkml
@@ -1,4 +1,4 @@
-connection: "snowflake_l"
+connection: "snowflake"
 include: "/**/**/*.view.lkml"
 fiscal_month_offset: -11
 week_start_day: sunday


### PR DESCRIPTION
#### Summary
Moving Looker TRANSFORM_L (Snowflake_L) workload to TRANSFORM_XS(Snowflake).
If the performance is onerous, we can discuss moving them to an intermediate warehouse (e.g. M).
