### PR TITLE
Chore: add fields to fct_active_servers view

### DIFF
--- a/views/marts/product/fct_active_servers.view.lkml
+++ b/views/marts/product/fct_active_servers.view.lkml
@@ -108,12 +108,27 @@ view: fct_active_servers {
     view_label: "Metadata: Data Source Info"
   }
 
-
   dimension: is_missing_activity_data {
     type: yesno
     sql: ${TABLE}."IS_MISSING_ACTIVITY_DATA" ;;
     label: "Missing activity data?"
     description: "Whether activity data were reported from telemetry pipeline (Rudderstack or Segment) at the current date."
+    view_label: "Metadata: Data Source Info"
+  }
+
+  dimension: is_feature_shared_channels_enabled {
+    type: yesno
+    sql: ${TABLE}."is_feature_shared_channels_enabled" ;;
+    label: "Is shared channels feature enabled?"
+    description: "Whether the shared channels feature has been enabled at the server."
+    view_label: "Metadata: Data Source Info"
+  }
+
+  dimension: is_feature_remote_cluster_service_enabled {
+    type: yesno
+    sql: ${TABLE}."is_feature_remote_cluster_service_enabled" ;;
+    label: "Is remote cluster feature enabled?"
+    description: "Whether the remote cluster feature has been enabled at the server."
     view_label: "Metadata: Data Source Info"
   }
 

--- a/views/marts/product/fct_active_servers.view.lkml
+++ b/views/marts/product/fct_active_servers.view.lkml
@@ -118,7 +118,7 @@ view: fct_active_servers {
 
   dimension: is_feature_shared_channels_enabled {
     type: yesno
-    sql: ${TABLE}."is_feature_shared_channels_enabled" ;;
+    sql: ${TABLE}.is_feature_shared_channels_enabled ;;
     label: "Is shared channels feature enabled?"
     description: "Whether the shared channels feature has been enabled at the server."
     view_label: "Metadata: Data Source Info"
@@ -126,7 +126,7 @@ view: fct_active_servers {
 
   dimension: is_feature_remote_cluster_service_enabled {
     type: yesno
-    sql: ${TABLE}."is_feature_remote_cluster_service_enabled" ;;
+    sql: ${TABLE}.is_feature_remote_cluster_service_enabled ;;
     label: "Is remote cluster feature enabled?"
     description: "Whether the remote cluster feature has been enabled at the server."
     view_label: "Metadata: Data Source Info"


### PR DESCRIPTION
#### Summary
Surfaces the fields added by https://github.com/mattermost/mattermost-data-warehouse/pull/1624 in the `fct_active_servers` view.