### PR TITLE
Chore: surface full server version info to the nps models

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -17,6 +17,12 @@ explore: fct_nps_score {
     type: left_outer
     sql_on: ${fct_nps_score.server_id} = ${dim_excludable_servers.server_id} ;;
   }
+
+  join: dim_version {
+    relationship:  many_to_one
+    type: full_outer
+    sql_on: ${fct_nps_score.version_id} = ${dim_version.version_id} ;;
+  }
 }
 
 explore: fct_nps_feedback {
@@ -27,6 +33,12 @@ explore: fct_nps_feedback {
     relationship: many_to_one
     type: left_outer
     sql_on: ${fct_nps_feedback.server_id} = ${dim_excludable_servers.server_id} ;;
+  }
+
+  join: dim_version {
+    relationship:  many_to_one
+    type: full_outer
+    sql_on: ${fct_nps_feedback.version_id} = ${dim_version.version_id} ;;
   }
 }
 

--- a/views/marts/product/fct_nps_feedback.view.lkml
+++ b/views/marts/product/fct_nps_feedback.view.lkml
@@ -51,11 +51,10 @@ view: fct_nps_feedback {
     view_label: "NPS Feedback: Metadata"
   }
 
-  dimension: server_version {
+ dimension: version_id {
     type: string
-    sql: ${TABLE}."SERVER_VERSION" ;;
-    label: "Server Version"
-    view_label: "NPS Feedback"
+    sql: ${TABLE}.version_id ;;
+    hidden: yes
   }
 
   dimension: user_email {

--- a/views/marts/product/fct_nps_score.view.lkml
+++ b/views/marts/product/fct_nps_score.view.lkml
@@ -285,13 +285,12 @@ view: fct_nps_score {
     sql: ${TABLE}."SERVER_ID" ;;
   }
 
-  dimension: server_version {
+  dimension: version_id {
     type: string
-    label: "Server Version"
-    view_label: "NPS Score"
-    sql: ${TABLE}."SERVER_VERSION" ;;
+    sql: ${TABLE}.version_id ;;
+    hidden: yes
   }
-
+  
   measure: count {
     type: count
     label: "Count"


### PR DESCRIPTION
#### Summary
Adds `version_id` to the `fct_nps_*` views to join with `dim_version`.
follow-up to https://github.com/mattermost/mattermost-data-warehouse/pull/1630