### PR TITLE
Chore: add license reference to nps-related views.

### DIFF
--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -27,7 +27,7 @@ explore: fct_nps_score {
   join: dim_daily_license {
     relationship: one_to_one
     type: left_outer
-    sql_on: ${fct_nps_score.server_id} = ${dim_daily_license.daily_server_id} ;;
+    sql_on: ${fct_nps_score.daily_server_id} = ${dim_daily_license.daily_server_id} ;;
   }
 }
 
@@ -50,7 +50,7 @@ explore: fct_nps_feedback {
   join: dim_daily_license {
     relationship: one_to_one
     type: left_outer
-    sql_on: ${fct_nps_feedback.server_id} = ${dim_daily_license.daily_server_id} ;;
+    sql_on: ${fct_nps_feedback.daily_server_id} = ${dim_daily_license.daily_server_id} ;;
   }
 }
 

--- a/models/product.model.lkml
+++ b/models/product.model.lkml
@@ -23,6 +23,12 @@ explore: fct_nps_score {
     type: full_outer
     sql_on: ${fct_nps_score.version_id} = ${dim_version.version_id} ;;
   }
+
+  join: dim_daily_license {
+    relationship: one_to_one
+    type: left_outer
+    sql_on: ${fct_nps_score.server_id} = ${dim_daily_license.daily_server_id} ;;
+  }
 }
 
 explore: fct_nps_feedback {
@@ -39,6 +45,12 @@ explore: fct_nps_feedback {
     relationship:  many_to_one
     type: full_outer
     sql_on: ${fct_nps_feedback.version_id} = ${dim_version.version_id} ;;
+  }
+
+  join: dim_daily_license {
+    relationship: one_to_one
+    type: left_outer
+    sql_on: ${fct_nps_feedback.server_id} = ${dim_daily_license.daily_server_id} ;;
   }
 }
 
@@ -88,7 +100,6 @@ explore: fct_active_users {
     type: left_outer
     sql_on: ${fct_active_users.daily_server_id} = ${dim_daily_license.daily_server_id} ;;
   }
-
 }
 
 explore: fct_active_servers {

--- a/views/marts/product/fct_nps_feedback.view.lkml
+++ b/views/marts/product/fct_nps_feedback.view.lkml
@@ -3,6 +3,13 @@ view: fct_nps_feedback {
   label: "NPS Feedback"
   sql_table_name: "MART_PRODUCT"."FCT_NPS_FEEDBACK" ;;
 
+  dimension: daily_server_id {
+    type: string
+    sql: ${TABLE}.daily_server_id ;;
+    primary_key: yes
+    hidden: yes
+  }
+
   dimension: feedback {
     type: string
     sql: ${TABLE}."FEEDBACK" ;;

--- a/views/marts/product/fct_nps_score.view.lkml
+++ b/views/marts/product/fct_nps_score.view.lkml
@@ -11,6 +11,12 @@ view: fct_nps_score {
     type: string
     sql: ${TABLE}."ID" ;;
   }
+   
+  dimension: daily_server_id {
+    type: string
+    sql: ${TABLE}.daily_server_id ;;
+    hidden: yes
+  }
 
   dimension_group: activity_date {
     type: time


### PR DESCRIPTION
#### Summary
Add license reference to nps-related views. This is to fix the nps-related errors in https://mattermost.looker.com/content_validator triggered by removing the `dim_*_customers` dimensions.